### PR TITLE
Extract OutImage block indices from header

### DIFF
--- a/src/pyimcom/analysis.py
+++ b/src/pyimcom/analysis.py
@@ -125,11 +125,9 @@ class OutImage:
         if hdu_names is None:
             self.hdu_names = OutImage.get_hdu_names(self.cfg.outmaps)
 
-        data_loaded = hasattr(self, "hdu_list")
-        if not data_loaded:
-            self.hdu_list = ReadFile(self.fpath)
+        with fits.open(self.fpath) as _hdul:
+            _header = _hdul["CONFIG"].header
 
-        _header = self.hdu_list["CONFIG"].header
         if ("BLOCKX" in _header) and ("BLOCKY" in _header):
             self.ibx = int(_header["BLOCKX"])
             self.iby = int(_header["BLOCKY"])


### PR DESCRIPTION
Now that the block indices are stored in the header, we can use that to extract them more reliably than parsing from the path name.

There are some caveats:
- this only works for recent runs of IMCOM; older runs still require filename parsing
- the filenames of the `testrun_fall2025` seem to catch on the parser, so I actually _needed_ this change to process those data