### PR TITLE
remove intermediate outputs

### DIFF
--- a/src/pyimcom/coadd.py
+++ b/src/pyimcom/coadd.py
@@ -2033,8 +2033,8 @@ class Block:
                             self.instamps[j_st + dj][i_st] = None
                 gc.collect()  # force a garbage collection
 
-                print("  --> intermediate output -->\n")
-                self.build_output_file(is_final=False)
+                # print("  --> intermediate output -->\n")
+                # self.build_output_file(is_final=False)
 
     @staticmethod
     def compress_map(


### PR DESCRIPTION
Writing these partially processed block output files every row isn't needed anymore, and they were taking ≈1% of the total time of IMCOM — not a lot, but worth saving.