### PR TITLE
Jwst destripe compatibility and column offsets

### DIFF
--- a/src/pyimcom/config.py
+++ b/src/pyimcom/config.py
@@ -122,6 +122,21 @@ class Settings:
         ]
     )
 
+    @classmethod
+    def jwst(cls):
+        """Method to modify the Settings object to have JWST NIRCam parameters
+        instead of Roman WFI parameters."""
+
+        cls.pixscale_native = 0.031 * cls.arcsec
+        cls.sca_nside = 2048
+        cls.sca_ctrpix = (cls.sca_nside - 1) / 2
+        cls.sca_sidelength = cls.sca_nside * cls.pixscale_native
+
+        # KL Leaving "Roman" so we don't have to change as much in the code
+        # KL Check these values though
+        cls.RomanFilters = ["F070W", "F090W", "F115W", "F150W", "F200W", "F277W", "F356W", "F444W"]  
+        cls.QFilterNative = [0.070, 0.090, 0.115, 0.150, 0.200, 0.277, 0.356, 0.444]
+
 
 class fpaCoords:
     """This contains some static data on the FPA coordinate system.

--- a/src/pyimcom/config.py
+++ b/src/pyimcom/config.py
@@ -28,7 +28,8 @@ import numpy as np
 from astropy import units as u
 from astropy.io import fits
 
-JWST = os.getenv("INSTRUMENT") == "NIRCAM"
+JWST = os.environ.get("INSTRUMENT", "WFI") == "NIRCAM" 
+# This will be True if the environment variable INSTRUMENT is set to "NIRCAM", and False otherwise. 
 
 class Timer:
     """

--- a/src/pyimcom/config.py
+++ b/src/pyimcom/config.py
@@ -28,8 +28,9 @@ import numpy as np
 from astropy import units as u
 from astropy.io import fits
 
-JWST = os.environ.get("INSTRUMENT", "WFI") == "NIRCAM" 
-# This will be True if the environment variable INSTRUMENT is set to "NIRCAM", and False otherwise. 
+JWST = os.environ.get("INSTRUMENT", "WFI") == "NIRCAM"
+# This will be True if the environment variable INSTRUMENT is set to "NIRCAM", and False otherwise.
+
 
 class Timer:
     """
@@ -127,18 +128,19 @@ class Settings:
 
     @classmethod
     def jwst(cls):
-        """Method to modify the Settings object to have JWST NIRCam parameters
-        instead of Roman WFI parameters."""
+        """
+        Method to modify the Settings object to have JWST NIRCam parameters
+        instead of Roman WFI parameters.
+
+        Note: Currently only includes those attributes that are used in imdestripe.py,
+        but more can be added as needed.
+
+        """
 
         cls.pixscale_native = 0.031 * cls.arcsec
         cls.sca_nside = 2048
-        cls.sca_ctrpix = (cls.sca_nside - 1) / 2
-        cls.sca_sidelength = cls.sca_nside * cls.pixscale_native
-
         # KL Leaving "Roman" so we don't have to change as much in the code
-        # KL Check these values though
-        cls.RomanFilters = ["F070W", "F090W", "F115W", "F150W", "F200W", "F277W", "F356W", "F444W"]  
-        cls.QFilterNative = [0.070, 0.090, 0.115, 0.150, 0.200, 0.277, 0.356, 0.444]
+        cls.RomanFilters = ["F070W", "F090W", "F115W", "F150W", "F200W", "F277W", "F356W", "F444W"]  # Y
 
 
 class fpaCoords:

--- a/src/pyimcom/config.py
+++ b/src/pyimcom/config.py
@@ -20,6 +20,7 @@ format_axis
 """
 
 import json
+import os
 from importlib.resources import files
 from time import perf_counter
 
@@ -27,6 +28,7 @@ import numpy as np
 from astropy import units as u
 from astropy.io import fits
 
+JWST = os.getenv("INSTRUMENT") == "NIRCAM"
 
 class Timer:
     """

--- a/src/pyimcom/config.py
+++ b/src/pyimcom/config.py
@@ -340,7 +340,10 @@ class Config:
         "hub_thresh",
         "cg_maxiter",
         "cg_tol",
-        "gaindir",  # SECTION IX
+        "gaindir", # SECTION IX
+        "col_pars",
+        "amp_cols",
+        "col_boundary_const",
         "tileschm",
         "rerun",
         "mosaic",  # SECTION X
@@ -543,6 +546,9 @@ class Config:
         self.ds_noisefile = cfg_dict.get("DSNOISEFILE", False)
         self.ds_restart = cfg_dict.get("DSRESTART")
         self.gaindir = cfg_dict.get("GAINDIR", False)
+        self.col_pars = cfg_dict.get("AMPCOLS", [None, 0.0])
+        self.amp_cols = self.col_pars[0]
+        self.col_boundary_const = self.col_pars[1]
 
         # Lagrange multiplier (kappa) information
         # list of kappa/C values, ascending order

--- a/src/pyimcom/config.py
+++ b/src/pyimcom/config.py
@@ -136,11 +136,21 @@ class Settings:
         but more can be added as needed.
 
         """
-
-        cls.pixscale_native = 0.031 * cls.arcsec
+        
         cls.sca_nside = 2048
+        nircam_short_bands = \
+        ['F070W', 'F090W', 'F115W', 'F140M', 'F150W', 'F150W2', 
+         'F162M', 'F164N', 'F182M', 'F187N', 'F200W', 'F210M', 
+         'F212N']
+        nircam_long_bands = \
+        ['F250M', 'F277W', 'F300M', 'F322W2', 'F323N', 
+         'F335M', 'F356W', 'F360M', 'F405N', 'F410M', 'F430M', 
+         'F444W', 'F460M', 'F466N', 'F470N', 'F480M']
         # KL Leaving "Roman" so we don't have to change as much in the code
-        cls.RomanFilters = ["F070W", "F090W", "F115W", "F150W", "F200W", "F277W", "F356W", "F444W"]  # Y
+        cls.RomanFilters = nircam_short_bands + nircam_long_bands
+
+        cls.pixscale_short_native = 0.031 * cls.arcsec
+        cls.pixscale_long_native = 0.062 * cls.arcsec
 
 
 class fpaCoords:

--- a/src/pyimcom/config.py
+++ b/src/pyimcom/config.py
@@ -136,19 +136,43 @@ class Settings:
         but more can be added as needed.
 
         """
-        
+
         cls.sca_nside = 2048
-        nircam_short_bands = \
-        ['F070W', 'F090W', 'F115W', 'F140M', 'F150W', 'F150W2', 
-         'F162M', 'F164N', 'F182M', 'F187N', 'F200W', 'F210M', 
-         'F212N']
-        nircam_long_bands = \
-        ['F250M', 'F277W', 'F300M', 'F322W2', 'F323N', 
-         'F335M', 'F356W', 'F360M', 'F405N', 'F410M', 'F430M', 
-         'F444W', 'F460M', 'F466N', 'F470N', 'F480M']
+        nircam_short_bands = [
+            "F070W",
+            "F090W",
+            "F115W",
+            "F140M",
+            "F150W",
+            "F150W2",
+            "F162M",
+            "F164N",
+            "F182M",
+            "F187N",
+            "F200W",
+            "F210M",
+            "F212N",
+        ]
+        nircam_long_bands = [
+            "F250M",
+            "F277W",
+            "F300M",
+            "F322W2",
+            "F323N",
+            "F335M",
+            "F356W",
+            "F360M",
+            "F405N",
+            "F410M",
+            "F430M",
+            "F444W",
+            "F460M",
+            "F466N",
+            "F470N",
+            "F480M",
+        ]
         # KL Leaving "Roman" so we don't have to change as much in the code
         cls.RomanFilters = nircam_short_bands + nircam_long_bands
-
         cls.pixscale_short_native = 0.031 * cls.arcsec
         cls.pixscale_long_native = 0.062 * cls.arcsec
 
@@ -340,7 +364,7 @@ class Config:
         "hub_thresh",
         "cg_maxiter",
         "cg_tol",
-        "gaindir", # SECTION IX
+        "gaindir",  # SECTION IX
         "col_pars",
         "amp_cols",
         "col_boundary_const",

--- a/src/pyimcom/imdestripe.py
+++ b/src/pyimcom/imdestripe.py
@@ -85,7 +85,7 @@ from astropy import wcs
 from astropy.io import fits
 from filelock import FileLock, Timeout
 from memory_profiler import memory_usage
-from scipy.ndimage import binary_dilation
+from scipy.ndimage import binary_dilation, binary_propagation
 
 from .config import JWST, Config, Settings
 from .utils import compareutils
@@ -225,7 +225,7 @@ class Sca_img:
                 self.shape = np.shape(self.image)
                 self._file_handle = None
                 self.type = "fits"
-                self.mask_threshold = [0, 0.3] # m, c for object masking
+                self.mask_threshold = [0, 0.3]  # m, c for object masking
                 file.close()
 
             elif indata_type == "asdf":
@@ -236,7 +236,7 @@ class Sca_img:
                 self.header = None
                 self.shape = np.shape(self.image)
                 self.type = "asdf"
-                self.mask_threshold = [0, 0.3] # m, c for object masking
+                self.mask_threshold = [0, 0.3]  # m, c for object masking
                 # Note: keep _file_handle open to maintain memmap
             elif indata_type == "jwst":
                 file = fits.open(
@@ -252,7 +252,7 @@ class Sca_img:
                 self.shape = np.shape(self.image)
                 self._file_handle = None
                 self.type = "jwst"
-                self.mask_threshold = [15, 5] # m, c for object masking
+                self.mask_threshold = [15, 5]  # m, c for object masking
                 file.close()
 
         self.obsid = obsid
@@ -308,7 +308,12 @@ class Sca_img:
                 self.apply_permanent_mask()
             elif indata_type == "jwst":
                 self.apply_jwst_mask()
-            _, object_mask = apply_object_mask(self.image, threshold_m=self.mask_threshold[0], threshold_c=self.mask_threshold[1], type=self.type)
+            _, object_mask = apply_object_mask(
+                self.image,
+                threshold_m=self.mask_threshold[0],
+                threshold_c=self.mask_threshold[1],
+                type=self.type,
+            )
             self.mask *= np.logical_not(
                 object_mask
             )  # self.mask = True for good pixels, so set object_mask'ed pixels to False
@@ -619,8 +624,25 @@ class Parameters:
             raise ValueError(f"Model {cfg.ds_model} not in model_params dictionary.")
         self.model = cfg.ds_model
         self.n_rows = cfg.ds_rows
+        self.n_cols = Settings.sca_nside
         self.params_per_row = model_params[self.model]
-        self.params = np.zeros((len(scalist), self.n_rows * self.params_per_row))
+
+        if cfg.amp_cols is not None and cfg.amp_cols > 0:
+            if self.n_cols % cfg.amp_cols != 0:
+                raise ValueError(
+                    f"Column width (amp_cols={cfg.amp_cols}) does not evenly divide "
+                    f"image columns ({self.n_cols}). Ensure n_cols % amp_cols == 0."
+                )
+            self.amp_cols = cfg.amp_cols
+            self.n_col_blocks = self.n_cols // cfg.amp_cols
+        else:
+            self.amp_cols = None
+            self.n_col_blocks = 0
+
+        params_per_row = self.n_rows * self.params_per_row
+        params_per_sca = params_per_row + self.n_col_blocks
+
+        self.params = np.zeros((len(scalist), params_per_sca))
         self.current_shape = "2D"
         self.scalist = scalist
 
@@ -634,7 +656,8 @@ class Parameters:
 
     def forward_par(self, sca_i):
         """
-        Takes one SCA row (n_rows) from the params and casts it into 2D (n_rows x n_rows)
+        Takes one SCA row (n_rows) from the params and casts it into 2D (n_rows x n_cols)
+        with additive row and column-block offsets.
 
         Parameters
         --------
@@ -643,11 +666,28 @@ class Parameters:
 
         Returns
         --------
-         2D np.array, the image of SCA_i's parameters
+         2D np.array, the image of SCA_i's parameters (stripe image)
         """
         if self.current_shape != "2D":
             self.params_2_images()
-        return np.array(self.params[sca_i, :])[:, np.newaxis] * np.ones((self.n_rows, self.n_rows))
+
+        params_row_len = self.n_rows * self.params_per_row
+
+        # Build row image using existing per-row logic
+        row_params = np.array(self.params[sca_i, :params_row_len])[:, np.newaxis]
+        row_image = row_params * np.ones((self.n_rows, self.n_cols))
+
+        # Build column-block image if enabled
+        if self.n_col_blocks > 0:
+            col_params = self.params[sca_i, params_row_len : params_row_len + self.n_col_blocks]
+            col_image = np.zeros((self.n_rows, self.n_cols))
+            for b in range(self.n_col_blocks):
+                j_start = b * self.amp_cols
+                j_end = j_start + self.amp_cols
+                col_image[:, j_start:j_end] = col_params[b]  # Broadcast over rows
+            return row_image + col_image
+        else:
+            return row_image
 
 
 def write_to_file(text, filename=None):
@@ -725,7 +765,14 @@ def save_fits(image, filename, dir=None, overwrite=True, s=False, header=None, r
                 raise RuntimeError(f"Failed to write {fp} after {retries} attempts. Last error: {e}") from e
 
 
-def apply_object_mask(image, mask=None, threshold_m=0, threshold_c=0.3, inplace=False, type="fits"):
+def apply_object_mask(
+    image,
+    mask=None,
+    threshold_m=0,
+    threshold_c=0.3,
+    inplace=False,
+    type="fits",
+):
     """
     Apply a bright object mask to an image.
 
@@ -756,16 +803,52 @@ def apply_object_mask(image, mask=None, threshold_m=0, threshold_c=0.3, inplace=
     else:
         median_val = np.median(image)
         if type == "jwst":
-            # We need tiered thresholding for JWST data because of vastly different sky scenes.
-            if median_val<0.1:
-                high_value_mask = image >= median_val + threshold_c
-            elif 0.1<median_val<0.4:
-                high_value_mask = image >= threshold_m * median_val + threshold_c
+            # Use robust background/noise estimation + seeded region growing for JWST scenes.
+            valid = np.isfinite(image)
+            if not np.any(valid):
+                high_value_mask = np.zeros_like(image, dtype=bool)
+                seed_threshold = 0.0
+                grow_threshold = 0.0
             else:
-                high_value_mask = image >= 0.5*threshold_m * median_val 
+                work = np.array(image, copy=True)
+                vals = work[valid]
+
+                # Iterative clipping to estimate sky background robustly.
+                clip_vals = vals
+                for _ in range(3):
+                    bkg = np.median(clip_vals)
+                    mad = np.median(np.abs(clip_vals - bkg))
+                    sigma = 1.4826 * mad
+                    if sigma <= 0:
+                        break
+                    keep = np.abs(clip_vals - bkg) < (3.0 * sigma)
+                    if np.count_nonzero(keep) < 100:
+                        break
+                    clip_vals = clip_vals[keep]
+
+                bkg = np.median(clip_vals)
+                mad = np.median(np.abs(clip_vals - bkg))
+                sigma = 1.4826 * mad
+                if not np.isfinite(sigma) or sigma <= 0:
+                    sigma = np.std(clip_vals) if clip_vals.size > 1 else 0.0
+
+                residual = np.zeros_like(work)
+                residual[valid] = work[valid] - bkg
+
+                # Two-level thresholding: bright seeds + lower-threshold growth.
+                seed_threshold = max(threshold_c, 6.0 * sigma)
+                grow_threshold = max(0.5 * threshold_c, 2.5 * sigma)
+
+                seed_mask = np.logical_and(valid, residual >= seed_threshold)
+                grow_candidates = np.logical_and(valid, residual >= grow_threshold)
+                grown_mask = binary_propagation(seed_mask, mask=grow_candidates)
+                high_value_mask = binary_dilation(
+                    grown_mask, structure=np.ones((3, 3), dtype=bool), iterations=2
+                )
+
         else:
             high_value_mask = image >= threshold_m * median_val + threshold_c
-            
+
         neighbor_mask = binary_dilation(high_value_mask, structure=np.ones((5, 5), dtype=bool))
 
     if inplace:
@@ -948,20 +1031,39 @@ def transpose_interpolate(image_A, wcs_A, image_B, original_image):
     pyimcom_croutines.bilinear_transpose(image_A, rows, cols, coords, num_coords, original_image)
 
 
-def transpose_par(img):
+def transpose_par(img, cfg=None):
     """
-    Sum up the values of an image across rows
+    Extract parameter contributions from an image via adjoint of forward_par.
+
+    For row-only model: sums each row across columns.
+    For row+column model: also sums each column-block across rows.
 
     Parameters
     --------
     img : 2D np.array
-        Input array
+        Input gradient/residual image
+    cfg : Config object or None
+        If provided and amp_cols is enabled, returns concatenated
+        [row_contributions, col_block_contributions]. If None, returns only row sums.
 
-     Returns
+    Returns
     --------
-       1D np.array, the sum across each row of I
+       1D np.array, concatenation of [row sums, column-block sums] if cfg enables col_blocks,
+       otherwise just row sums (backward compatible)
     """
-    return np.sum(img, axis=1)
+    row_contrib = np.sum(img, axis=1)
+
+    if cfg is not None and hasattr(cfg, "amp_cols") and cfg.amp_cols is not None and cfg.amp_cols > 0:
+        n_cols = img.shape[1]  # Use actual image width, not Settings.sca_nside
+        n_col_blocks = n_cols // cfg.amp_cols
+        col_contrib = np.zeros(n_col_blocks)
+        for b in range(n_col_blocks):
+            j_start = b * cfg.amp_cols
+            j_end = j_start + cfg.amp_cols
+            col_contrib[b] = np.sum(img[:, j_start:j_end])  # Sum over all rows in this block
+        return np.concatenate([row_contrib, col_contrib])
+    else:
+        return row_contrib
 
 
 def get_effective_gain(sca, tempdir=tempdir, indata_type="fits"):
@@ -1278,7 +1380,7 @@ def residual_function_single(
     # Calculate and then transpose the gradient of I_A-J_A
     gradient_interpolated = f_prime(psi_a, thresh) if thresh is not None else f_prime(psi_a)
 
-    term_1 = transpose_par(gradient_interpolated)
+    term_1 = transpose_par(gradient_interpolated, cfg=cfg)
 
     # Retrieve the effective gain and N_eff to normalize the gradient before transposing back
     g_eff_A, n_eff_A = get_effective_gain(sca_a, indata_type=indata_type)
@@ -1303,7 +1405,7 @@ def residual_function_single(
         transpose_interpolate(gradient_interpolated, wcs_a, I_B, gradient_original)
         gradient_original *= I_B.g_eff
 
-        term_2 = transpose_par(gradient_original)
+        term_2 = transpose_par(gradient_original, cfg=cfg)
         term_2_list.append((j, term_2))
 
     #     I_B.close()
@@ -2124,7 +2226,7 @@ def main(cfg_file=None, overlaponly=False, of=None, testing=False):
 
     """
     global img_full_output
-    
+
     CG_models = {"FR", "PR", "HS", "DY"}
 
     if cfg_file is None:
@@ -2134,22 +2236,23 @@ def main(cfg_file=None, overlaponly=False, of=None, testing=False):
         CFG = Config(cfg_file=cfg_file)
     else:
         raise ValueError("Please provide a config file as a command line argument.")
-    
+
     outpath = CFG.ds_outpath
-    if JWST:   
-        indata_type = "jwst" 
+    if JWST:
+        indata_type = "jwst"
         filter_ = CFG.use_filter
     else:
         indata_type = "fits"
         filter_ = filters[CFG.use_filter]
-    if testing: testoutputs["testing"] = True
+    if testing:
+        testoutputs["testing"] = True
 
     # For test outputs: set sca=0 to not produce test outputs.
-    img_full_output = {"obsid": "04793009001_02101_00001", "scaid": "nrcb2"} if JWST else {"obsid": 670, "scaid": 10}
+    img_full_output = (
+        {"obsid": "04793009001_02101_00001", "scaid": "nrcb2"} if JWST else {"obsid": 670, "scaid": 10}
+    )
     if not testoutputs["testing"]:
         img_full_output = {"obsid": -1, "scaid": -1}  # don't do these big outputs
-
-
 
     # Prior on cost function is not yet implemented
     # if CFG.cost_prior != 0:

--- a/src/pyimcom/imdestripe.py
+++ b/src/pyimcom/imdestripe.py
@@ -87,7 +87,7 @@ from filelock import FileLock, Timeout
 from memory_profiler import memory_usage
 from scipy.ndimage import binary_dilation
 
-from .config import Config, Settings
+from .config import Config, Settings, JWST
 from .utils import compareutils
 from .wcsutil import PyIMCOM_WCS
 
@@ -109,7 +109,7 @@ testoutputs = {
 warnings.filterwarnings("ignore", category=AsdfConversionWarning)
 warnings.filterwarnings("ignore", category=AsdfPackageVersionWarning)
 
-# from Config.Settings import RomanFilters as filters
+if JWST: Settings.jwst()
 filters = Settings.RomanFilters
 t0_global = time.time()  # after imports
 

--- a/src/pyimcom/imdestripe.py
+++ b/src/pyimcom/imdestripe.py
@@ -214,6 +214,7 @@ class Sca_img:
             self.header = file[image_hdu].header
             self.shape = np.shape(self.image)
             self._file_handle = None
+            self.type = "interpolated"
             file.close()
         else:
             if indata_type == "fits":
@@ -227,6 +228,7 @@ class Sca_img:
                 self.header = file[image_hdu].header
                 self.shape = np.shape(self.image)
                 self._file_handle = None
+                self.type = "fits"
                 file.close()
 
             elif indata_type == "asdf":
@@ -236,6 +238,7 @@ class Sca_img:
                 self.image = np.array(self._file_handle["roman"]["data"], dtype=np.float64)
                 self.header = None
                 self.shape = np.shape(self.image)
+                self.type = "asdf"
                 # Note: keep _file_handle open to maintain memmap
             elif indata_type=="jwst":
                 file = fits.open(
@@ -250,6 +253,7 @@ class Sca_img:
                 self.header = file[image_hdu].header
                 self.shape = np.shape(self.image)
                 self._file_handle = None
+                self.type = "jwst"
                 file.close()
 
         self.obsid = obsid
@@ -501,7 +505,7 @@ class Sca_img:
             obsid_B, scaid_B = get_ids(sca_b)
 
             N_BinA += 1
-            I_B = Sca_img(obsid_B, scaid_B, self.cfg)  # Initialize image B
+            I_B = Sca_img(obsid_B, scaid_B, self.cfg, indata_type=self.type)  # Initialize image B
 
             if params:
                 I_B.subtract_parameters(params, k)
@@ -817,25 +821,39 @@ def get_scas(filter_, obsfile, cfg, indata_type="fits", of=None):
     n_scas = 0
     all_scas = []
     all_wcs = []
-    for f in sorted(glob.glob(obsfile + filter_ + "_*")):
-        m = re.search(r"(\w\d+)_(\d+)_(\d+)", f)
-        if m:
-            if indata_type == "fits":
+
+    if indata_type == "jwst":
+        for f in sorted(glob.glob(obsfile + "*_cpr.fits")):
+            # example to match: jw04793001001_02101_00001_nrcb1_crf.fits
+            m = re.search(r"jw(\d+)_(\d+)_(\d+)_(\d+)_(nrcb\d+)", f) 
+            if m:
                 n_scas += 1
                 this_obsfile = str(m.group(0))
                 all_scas.append(this_obsfile)
                 this_file = fits.open(f, memmap=True)
-                this_wcs = wcs.WCS(this_file["PRIMARY"].header)
+                this_wcs = wcs.WCS(this_file["SCI"].header)
                 all_wcs.append(this_wcs)
                 this_file.close()
-            elif indata_type == "asdf":
-                if ("noise" not in f) and ("mask" not in f):
+    else:
+        for f in sorted(glob.glob(obsfile + filter_ + "_*")):
+            m = re.search(r"(\w\d+)_(\d+)_(\d+)", f)
+            if m:
+                if indata_type == "fits":
                     n_scas += 1
                     this_obsfile = str(m.group(0))
                     all_scas.append(this_obsfile)
-                    with asdf.open(f, memmap=False, lazy_load=True) as this_file:
-                        this_wcs = PyIMCOM_WCS(this_file["roman"]["meta"]["wcs"])
-                        all_wcs.append(this_wcs)
+                    this_file = fits.open(f, memmap=True)
+                    this_wcs = wcs.WCS(this_file["PRIMARY"].header)
+                    all_wcs.append(this_wcs)
+                    this_file.close()
+                elif indata_type == "asdf":
+                    if ("noise" not in f) and ("mask" not in f):
+                        n_scas += 1
+                        this_obsfile = str(m.group(0))
+                        all_scas.append(this_obsfile)
+                        with asdf.open(f, memmap=False, lazy_load=True) as this_file:
+                            this_wcs = PyIMCOM_WCS(this_file["roman"]["meta"]["wcs"])
+                            all_wcs.append(this_wcs)
 
     write_to_file(f"N SCA images in this mosaic: {str(n_scas)}", of)
     write_to_file("------- SCA List -------", of)
@@ -934,7 +952,7 @@ def transpose_par(img):
     return np.sum(img, axis=1)
 
 
-def get_effective_gain(sca, tempdir=tempdir):
+def get_effective_gain(sca, tempdir=tempdir, indata_type="fits"):
     """
     Retrieve the effective gain and n_eff of the image. valid only for already-interpolated images
 
@@ -944,6 +962,8 @@ def get_effective_gain(sca, tempdir=tempdir):
         format like "<prefix>_<obsid>_<scaid>" describing which SCA to get the effective gain for
     tempdir : Str
         directory where the effective gain files are stored
+    indata_type : Str
+        The type of input data; default "fits"
 
     Returns
     --------
@@ -952,9 +972,15 @@ def get_effective_gain(sca, tempdir=tempdir):
     N_eff : memmap 2D np.array
         how many image "B"s contributed to that interpolated image
     """
-    m = re.search(r"_(\d+)_(\d+)", sca)
-    obsid = m.group(1)
-    scaid = m.group(2)
+    if indata_type == "fits":
+        m = re.search(r"_(\d+)_(\d+)", sca)
+        obsid = m.group(1)
+        scaid = m.group(2)
+    elif indata_type == "jwst":
+        m = re.search(r"jw(\d+)_(\d+)_(\d+)_(\d+)_(nrcb\d+)", sca)
+        obsid = m.group(1) + "_" + m.group(2) + "_" + m.group(3) + "_" + m.group(4)
+        scaid = m.group(5)
+
     g_eff = np.memmap(
         tempdir + obsid + "_" + scaid + "_geff.dat",
         dtype="float64",
@@ -970,7 +996,7 @@ def get_effective_gain(sca, tempdir=tempdir):
     return g_eff, N_eff
 
 
-def get_ids(sca):
+def get_ids(sca, indata_type="fits"):
     """
     Take an SCA label and parse it out to get the Obsid and SCA id strings.
 
@@ -978,6 +1004,8 @@ def get_ids(sca):
     --------
     sca : Str
         The sca name from all_scas list, formatted like <obsid>_<scaid>
+    indata_type : Str
+        The type of input data; default "fits"
 
     Returns
     --------
@@ -986,9 +1014,14 @@ def get_ids(sca):
     scaid : Str
         the SCA ID (position in focal plane)
     """
-    m = re.search(r"_(\d+)_(\d+)", sca)
-    obsid = m.group(1)
-    scaid = m.group(2)
+    if indata_type == "fits":
+        m = re.search(r"_(\d+)_(\d+)", sca)
+        obsid = m.group(1)
+        scaid = m.group(2)
+    elif indata_type == "jwst":
+        m = re.search(r"jw(\d+)_(\d+)_(\d+)_(\d+)_(nrcb\d+)", sca) 
+        obsid = m.group(1) + "_" + m.group(2) + "_" + m.group(3) + "_" + m.group(4)
+        scaid = m.group(5)
     return obsid, scaid
 
 
@@ -1090,7 +1123,7 @@ def get_neighbors(scalist, ov_mat, overlap_thresh=0.1):
 
 
 def residual_function(
-    psi, f_prime, scalist, wcslist, neighbors, thresh, workers, cfg, extrareturn=False, of=None
+    psi, f_prime, scalist, wcslist, neighbors, thresh, workers, cfg, extrareturn=False, of=None, indata_type="fits"
 ):
     """
     Calculate the residual image, = grad(epsilon)
@@ -1119,6 +1152,8 @@ def residual_function(
             in addition to full residuals. returns resids, resids1, resids2
     of : Str
         filename to write output info to, or if None, output is directed to stdout
+    indata_type : Str
+        input data type: One of 'fits', 'asdf', 'jwst'. Default 'fits'
 
     Returns
     --------
@@ -1148,6 +1183,7 @@ def residual_function(
                 thresh,
                 cfg,
                 of=of,
+                indata_type=indata_type,
             )
             for k, sca_a in enumerate(scalist)
         ]
@@ -1173,7 +1209,7 @@ def residual_function(
     return resids
 
 
-def residual_function_single(k, sca_a, wcs_a, psi_a, f_prime, scalist, neighbors, thresh, cfg, of=None):
+def residual_function_single(k, sca_a, wcs_a, psi_a, f_prime, scalist, neighbors, thresh, cfg, of=None, indata_type="fits"):
     """
     Calculate the residual for a single SCA image
 
@@ -1199,6 +1235,8 @@ def residual_function_single(k, sca_a, wcs_a, psi_a, f_prime, scalist, neighbors
         the configuration for this run
     of : Str
         filename to write output info to, or if None, output is directed to stdout
+    indata_type : Str
+        input data type: One of 'fits', 'asdf', 'jwst'. Default 'fits'
 
     Returns
     --------
@@ -1235,7 +1273,7 @@ def residual_function_single(k, sca_a, wcs_a, psi_a, f_prime, scalist, neighbors
         sca_b = scalist[j]
         obsid_B, scaid_B = get_ids(sca_b)
 
-        I_B = Sca_img(obsid_B, scaid_B, cfg)
+        I_B = Sca_img(obsid_B, scaid_B, cfg, indata_type=indata_type)  # Initialize image B
         gradient_original = np.zeros(I_B.shape)
 
         transpose_interpolate(gradient_interpolated, wcs_a, I_B, gradient_original)
@@ -1252,7 +1290,7 @@ def residual_function_single(k, sca_a, wcs_a, psi_a, f_prime, scalist, neighbors
     return k, term_1, term_2_list
 
 
-def cost_function_single(j, sca_a, p, f, scalist, neighbors, thresh, cfg, of=None):
+def cost_function_single(j, sca_a, p, f, scalist, neighbors, thresh, cfg, of=None, indata_type="fits"):
     """
     Calculate the cost function for a single SCA image
 
@@ -1276,6 +1314,8 @@ def cost_function_single(j, sca_a, p, f, scalist, neighbors, thresh, cfg, of=Non
         the configuration for this run
     of : Str
         filename to write output info to, or if None, output is directed to stdout
+    indata_type : Str
+        input data type: One of 'fits', 'asdf', 'jwst'. Default 'fits'
 
     Returns
     --------
@@ -1286,10 +1326,15 @@ def cost_function_single(j, sca_a, p, f, scalist, neighbors, thresh, cfg, of=Non
     local_epsilon : Float
         the cost function value for this SCA
     """
-    m = re.search(r"_(\d+)_(\d+)", sca_a)
-    obsid_A, scaid_A = m.group(1), m.group(2)
+    if indata_type == "fits":
+        m = re.search(r"_(\d+)_(\d+)", sca_a)
+        obsid_A, scaid_A = m.group(1), m.group(2)
+    elif indata_type == "jwst":
+        m = re.search(r"jw(\d+)_(\d+)_(\d+)_(\d+)_(nrcb\d+)", sca_a)
+        obsid_A = m.group(1) + "_" + m.group(2) + "_" + m.group(3) + "_" + m.group(4)
+        scaid_A = m.group(5)
 
-    I_A = Sca_img(obsid_A, scaid_A, cfg)
+    I_A = Sca_img(obsid_A, scaid_A, cfg, indata_type=indata_type)
     I_A.subtract_parameters(p, j)
     I_A.apply_all_mask()
 
@@ -1335,7 +1380,7 @@ def cost_function_single(j, sca_a, p, f, scalist, neighbors, thresh, cfg, of=Non
     return j, psi, local_epsilon
 
 
-def cost_function(p, f, thresh, workers, scalist, neighbors, cfg, tempdir=tempdir, of=None):
+def cost_function(p, f, thresh, workers, scalist, neighbors, cfg, tempdir=tempdir, of=None, indata_type="fits"):
     """
     Calculate the cost function with the current de-striping parameters.
 
@@ -1359,6 +1404,8 @@ def cost_function(p, f, thresh, workers, scalist, neighbors, cfg, tempdir=tempdi
         directory to store temporary files
     of : Str
         filename to write output info to, or if None, output is directed to stdout
+    indata_type : Str
+        input data type: One of 'fits', 'asdf', 'jwst'. Default 'fits'
 
     Returns
     --------
@@ -1380,7 +1427,7 @@ def cost_function(p, f, thresh, workers, scalist, neighbors, cfg, tempdir=tempdi
 
     with ProcessPoolExecutor(max_workers=workers) as executor:
         futures = [
-            executor.submit(cost_function_single, j, sca_a, p, f, scalist, neighbors, thresh, cfg, of=of)
+            executor.submit(cost_function_single, j, sca_a, p, f, scalist, neighbors, thresh, cfg, of=of, indata_type=indata_type)
             for j, sca_a in enumerate(scalist)
         ]
 
@@ -1419,6 +1466,7 @@ def linear_search_general(
     n_iter=100,
     tol=10**-4,
     of=None,
+    indata_type="fits",
 ):
     """
     Linear search via combination bisection and secant methods for parameters that minimize the function
@@ -1460,6 +1508,8 @@ def linear_search_general(
          absolute value of d_cost at which to converge
     of : Str
         filename to write output info to, or if None, output is directed to stdout
+    indata_type : Str
+        input data type: One of 'fits', 'asdf', 'jwst'. Default 'fits'
 
     Returns
     --------
@@ -1503,15 +1553,15 @@ def linear_search_general(
     write_to_file("### Calculating min and max epsilon and cost", of)
     max_params = p.params + alpha_max * direction
     max_p.params = max_params
-    max_epsilon, max_psi = cost_function(max_p, f, thresh, workers, scalist, neighbors, cfg)
-    max_resids = residual_function(max_psi, f_prime, scalist, wcslist, neighbors, thresh, workers, cfg)
+    max_epsilon, max_psi = cost_function(max_p, f, thresh, workers, scalist, neighbors, cfg, indata_type=indata_type)
+    max_resids = residual_function(max_psi, f_prime, scalist, wcslist, neighbors, thresh, workers, cfg, indata_type=indata_type)
     del max_psi
     d_cost_max = np.sum(max_resids * direction)
 
     min_params = p.params + alpha_min * direction
     min_p.params = min_params
-    min_epsilon, min_psi = cost_function(min_p, f, thresh, workers, scalist, neighbors, cfg)
-    min_resids = residual_function(min_psi, f_prime, scalist, wcslist, neighbors, thresh, workers, cfg)
+    min_epsilon, min_psi = cost_function(min_p, f, thresh, workers, scalist, neighbors, cfg, indata_type=indata_type)
+    min_resids = residual_function(min_psi, f_prime, scalist, wcslist, neighbors, thresh, workers, cfg, indata_type=indata_type)
     del min_psi
     d_cost_min = np.sum(min_resids * direction)
 
@@ -1548,10 +1598,10 @@ def linear_search_general(
         working_params = p.params + alpha_test * direction
         working_p.params = working_params
 
-        working_epsilon, working_psi = cost_function(working_p, f, thresh, workers, scalist, neighbors, cfg)
+        working_epsilon, working_psi = cost_function(working_p, f, thresh, workers, scalist, neighbors, cfg, indata_type=indata_type)
         print(f"Global elapsed t = {(time.time()-t0_global)/60:8.1f}")
         working_resids = residual_function(
-            working_psi, f_prime, scalist, wcslist, neighbors, thresh, workers, cfg
+            working_psi, f_prime, scalist, wcslist, neighbors, thresh, workers, cfg, indata_type=indata_type
         )
         print(f"Global elapsed t = {(time.time()-t0_global)/60:8.1f}")
         d_cost = np.sum(working_resids * direction)
@@ -1598,7 +1648,7 @@ def linear_search_general(
 
 
 def linear_search_quadratic(
-    p, direction, f, f_prime, grad_current, thresh, workers, scalist, wcslist, neighbors, cfg, of=None
+    p, direction, f, f_prime, grad_current, thresh, workers, scalist, wcslist, neighbors, cfg, of=None, indata_type="fits"
 ):
     """
     For the quadratic cost function, direct calculation of alpha that minimizes the function
@@ -1633,6 +1683,8 @@ def linear_search_quadratic(
         the configuration for this run
     of : Str
         filename to write output info to, or if None, output is directed to stdout
+    indata_type : Str
+        input data type: One of 'fits', 'asdf', 'jwst'. Default '
 
     Returns
     --------
@@ -1660,8 +1712,8 @@ def linear_search_quadratic(
     # Calculate
     trial_params = p.params + alpha_max * direction
     trial_p.params = trial_params
-    trial_epsilon, trial_psi = cost_function(trial_p, f, thresh, workers, scalist, neighbors, cfg)
-    trial_resids = residual_function(trial_psi, f_prime, scalist, wcslist, neighbors, thresh, workers, cfg)
+    trial_epsilon, trial_psi = cost_function(trial_p, f, thresh, workers, scalist, neighbors, cfg, indata_type=indata_type)
+    trial_resids = residual_function(trial_psi, f_prime, scalist, wcslist, neighbors, thresh, workers, cfg, indata_type=indata_type)
     del trial_psi, trial_epsilon
 
     alpha_new = (
@@ -1672,7 +1724,7 @@ def linear_search_quadratic(
 
     new_params = p.params + alpha_new * direction
     new_p.params = new_params
-    new_epsilon, new_psi = cost_function(new_p, f, thresh, workers, scalist, neighbors, cfg)
+    new_epsilon, new_psi = cost_function(new_p, f, thresh, workers, scalist, neighbors, cfg, indata_type=indata_type)
     new_resids = grad_current + (alpha_new / alpha_max) * (trial_resids - grad_current)
     write_to_file(f"(Inside LS) Global elapsed t = {(time.time()-t0_global)/60:8.1f}", of)
     sys.stdout.flush()
@@ -1707,6 +1759,7 @@ def conjugate_gradient(
     time_limit=None,
     cfg=None,
     of=None,
+    indata_type="fits",
 ):
     """
     Algorithm to use conjugate gradient descent to optimize the parameters for destriping.
@@ -1737,7 +1790,9 @@ def conjugate_gradient(
     cfg : config object
         containing all config parameters
     of : Str
-        output file to write log messages to
+        output file to write log messages to. If None, messages are printed to stdout
+    indata_type : Str
+        the type of input data; default "fits"
 
     Returns
     --------
@@ -1782,7 +1837,7 @@ def conjugate_gradient(
         grad = None
         direction = None  # No initial direction
         write_to_file("### Starting initial cost function", of)
-        epsilon, psi = cost_function(p, f, thresh, workers, scalist, neighbors, cfg)
+        epsilon, psi = cost_function(p, f, thresh, workers, scalist, neighbors, cfg, indata_type=indata_type)
         print(f"Global elapsed t = {(time.time()-t0_global)/60:8.1f}")
 
         with open(log_file, "w", newline="") as csvfile:
@@ -1813,7 +1868,7 @@ def conjugate_gradient(
 
         # Compute the gradient
         if grad is None:
-            grad = residual_function(psi, f_prime, scalist, wcslist, neighbors, thresh, workers, cfg)
+            grad = residual_function(psi, f_prime, scalist, wcslist, neighbors, thresh, workers, cfg, indata_type=indata_type)
             write_to_file(
                 f"Minutes spent in initial residual function: {(time.time() - t_start_CG_iter) / 60}", of
             )
@@ -1867,7 +1922,7 @@ def conjugate_gradient(
 
         if cost_model == "quadratic":
             p_new, psi_new, grad_new, epsilon_new = linear_search_quadratic(
-                p, direction, f, f_prime, grad, thresh, workers, scalist, wcslist, neighbors, cfg, of=of
+                p, direction, f, f_prime, grad, thresh, workers, scalist, wcslist, neighbors, cfg, of=of, indata_type=indata_type
             )
 
         else:
@@ -1887,6 +1942,8 @@ def conjugate_gradient(
                 neighbors,
                 cfg,
                 of=of,
+                indata_type=indata_type
+
             )
 
         write_to_file(f"Global elapsed t = {(time.time()-t0_global)/60:8.1f}", of)
@@ -2004,6 +2061,7 @@ def main(cfg_file=None, overlaponly=False, of=None):
 
     filter_ = filters[CFG.use_filter]
     outpath = CFG.ds_outpath
+    indata_type = "jwst" if JWST else "fits"
 
     # Prior on cost function is not yet implemented
     # if CFG.cost_prior != 0:
@@ -2019,7 +2077,7 @@ def main(cfg_file=None, overlaponly=False, of=None):
     workers = os.cpu_count() // int(os.environ["OMP_NUM_THREADS"]) if "OMP_NUM_THREADS" in os.environ else 12
     write_to_file(f"## Using {workers} workers for parallel processing.", of)
 
-    all_scas, all_wcs = get_scas(filter_, CFG.ds_obsfile, CFG, indata_type="fits", of=of)
+    all_scas, all_wcs = get_scas(filter_, CFG.ds_obsfile, CFG, indata_type=indata_type, of=of)
     write_to_file(f"{len(all_scas)} SCAs in this mosaic", of)
     sys.stdout.flush()
 
@@ -2058,6 +2116,7 @@ def main(cfg_file=None, overlaponly=False, of=None):
             time_limit=7200,
             cfg=CFG,
             of=of,
+            indata_type=indata_type,
         )
         hdu = fits.PrimaryHDU(p.params)
         hdu.writeto(outpath + "final_params.fits", overwrite=True)
@@ -2071,7 +2130,7 @@ def main(cfg_file=None, overlaponly=False, of=None):
 
     for i, sca in enumerate(all_scas):
         obsid, scaid = get_ids(sca)
-        this_sca = Sca_img(obsid, scaid, CFG, add_objmask=False)
+        this_sca = Sca_img(obsid, scaid, CFG, add_objmask=False, indata_type=indata_type)
         this_param_set = p.forward_par(i)
         ds_image = this_sca.image - this_param_set
 

--- a/src/pyimcom/imdestripe.py
+++ b/src/pyimcom/imdestripe.py
@@ -1416,6 +1416,75 @@ def residual_function_single(
     return k, term_1, term_2_list
 
 
+def compute_boundary_continuity_penalty(destriped_image, mask, amp_cols, col_boundary_const):
+    """
+    Penalize large discontinuities in the destriped image across amp-width
+    boundaries, making the final destriped image continuous even if individual parameters
+    are discontinuous.
+
+    The discontinuity is measured as the median absolute difference in destriped values
+    across boundaries, computed over non-masked pixels in chunks of ~100 rows.
+    Using the median makes the penalty robust to pixel-level noise and masked regions.
+
+    Parameters
+    ----------
+    destriped_image : 2D np.array
+        The destriped image I_A, already masked
+    mask : 2D bool array
+        The mask (True = good pixels), same shape as destriped_image
+    amp_cols : int or None
+        Column-block width. If None or <= 0, no penalty.
+    col_boundary_const : int
+        Strength of the column boundary penalty. If <= 0, no penalty.
+
+    Returns
+    -------
+    penalty : float
+        Scalar penalty value to add to cost function
+    """
+    if amp_cols is None or amp_cols <= 0:
+        return 0.0
+
+    lambda_reg = col_boundary_const
+    if lambda_reg <= 0:
+        return 0.0
+
+    n_rows, n_cols = destriped_image.shape
+    n_col_blocks = n_cols // amp_cols
+    chunk_size = 100  # ~100 rows per chunk for robustness
+
+    penalty = 0.0
+
+    # Loop over each column-block boundary
+    for b in range(1, n_col_blocks):
+        left_col_idx = b * amp_cols - 1
+        right_col_idx = b * amp_cols
+
+        # Loop over row chunks
+        for chunk_start in range(0, n_rows, chunk_size):
+            chunk_end = min(chunk_start + chunk_size, n_rows)
+            chunk_rows = slice(chunk_start, chunk_end)
+
+            # Extract left and right columns for this chunk
+            left_vals = destriped_image[chunk_rows, left_col_idx]
+            right_vals = destriped_image[chunk_rows, right_col_idx]
+            left_mask = mask[chunk_rows, left_col_idx]
+            right_mask = mask[chunk_rows, right_col_idx]
+
+            # Only include pixels where both sides are unmasked
+            valid = left_mask & right_mask
+
+            if np.any(valid):
+                # Compute discontinuities for valid pixels only
+                discontinuities = left_vals[valid] - right_vals[valid]
+                # Use median discontinuity to be robust to outliers
+                median_disc = np.median(discontinuities)
+                # Square and accumulate (penalizes both positive and negative discontinuities equally)
+                penalty += median_disc**2
+
+    return lambda_reg * penalty
+
+
 def cost_function_single(j, sca_a, p, f, scalist, neighbors, thresh, cfg, of=None, indata_type="fits"):
     """
     Calculate the cost function for a single SCA image
@@ -1475,6 +1544,19 @@ def cost_function_single(j, sca_a, p, f, scalist, neighbors, thresh, cfg, of=Non
     psi = np.where(J_A_mask, I_A.image - J_A_image, 0).astype("float32")
     result = f(psi, thresh) if thresh is not None else f(psi)
     local_epsilon = np.sum(result)
+
+    # Add boundary continuity penalty if column-block offsets are enabled
+    if cfg.amp_cols is not None and cfg.amp_cols > 0 and cfg.col_boundary_const > 0:
+        # Build the full destriped image with mask applied (True = good pixels to evaluate)
+        boundary_penalty = compute_boundary_continuity_penalty(
+            I_A.image, I_A.mask, cfg.amp_cols, cfg.col_boundary_const
+        )
+        local_epsilon += boundary_penalty
+        write_to_file(
+            f"SCA {j}: boundary continuity penalty = {boundary_penalty:.2e}, "
+            f"total cost = {local_epsilon:.2e}",
+            of,
+        )
 
     if img_full_output["scaid"] != 0 and testoutputs["testing"] and example_obs and example_sca:
         hdu = fits.PrimaryHDU(J_A_image * J_A_mask)

--- a/src/pyimcom/imdestripe.py
+++ b/src/pyimcom/imdestripe.py
@@ -87,7 +87,7 @@ from filelock import FileLock, Timeout
 from memory_profiler import memory_usage
 from scipy.ndimage import binary_dilation
 
-from .config import Config, Settings, JWST
+from .config import JWST, Config, Settings
 from .utils import compareutils
 from .wcsutil import PyIMCOM_WCS
 
@@ -109,7 +109,8 @@ testoutputs = {
 warnings.filterwarnings("ignore", category=AsdfConversionWarning)
 warnings.filterwarnings("ignore", category=AsdfPackageVersionWarning)
 
-if JWST: Settings.jwst()
+if JWST:
+    Settings.jwst()
 filters = Settings.RomanFilters
 t0_global = time.time()  # after imports
 
@@ -240,11 +241,11 @@ class Sca_img:
                 self.shape = np.shape(self.image)
                 self.type = "asdf"
                 # Note: keep _file_handle open to maintain memmap
-            elif indata_type=="jwst":
+            elif indata_type == "jwst":
                 file = fits.open(
-                    cfg.ds_obsfile + obsid + "_" + scaid + "_cpr.fits",
+                    cfg.ds_obsfile + obsid + "_" + scaid + "_crf.fits",
                     memmap=True,
-                ) # ds_obsfile is 'path/to/jw' 
+                )  # ds_obsfile is 'path/to/jw'
                 # obsid is <ppppp><ooo><vvv>_<gg><s><aa>_<eeeee>
                 # scaid is nrcb<n>
                 image_hdu = "SCI"
@@ -396,9 +397,10 @@ class Sca_img:
         """
         Apply JWST data quality mask. Updates self.image and self.mask
         """
-        mask = np.where(self.image==np.nan, 0, 1) 
-        self.image *= mask # this will set NaN pixels to 0 in the image, and keep the rest unchanged
-        self.mask *= mask # this will set the mask to 0 for NaN pixels, and keep the rest unchanged
+        # JWST bad pixels are represented as NaN in SCI; map them to zero and mark as masked.
+        valid = ~np.isnan(self.image)
+        self.image = np.where(valid, self.image, 0.0)
+        self.mask = np.logical_and(self.mask, valid)
 
     def apply_all_mask(self):
         """
@@ -406,8 +408,8 @@ class Sca_img:
         Updates self.image in-place
         """
         # Multiply by mask but set Nans to zero
-        self.image = np.where(np.isnan(self.image), 0, self.image*self.mask) 
-        # self.image *= self.mask 
+        self.image = np.where(np.isnan(self.image), 0, self.image * self.mask)
+        # self.image *= self.mask
 
     def subtract_parameters(self, p, j):
         """
@@ -502,7 +504,7 @@ class Sca_img:
 
         for k in sca_b_list:
             sca_b = scalist[k]
-            obsid_B, scaid_B = get_ids(sca_b)
+            obsid_B, scaid_B = get_ids(sca_b, indata_type=self.type)
 
             N_BinA += 1
             I_B = Sca_img(obsid_B, scaid_B, self.cfg, indata_type=self.type)  # Initialize image B
@@ -823,12 +825,12 @@ def get_scas(filter_, obsfile, cfg, indata_type="fits", of=None):
     all_wcs = []
 
     if indata_type == "jwst":
-        for f in sorted(glob.glob(obsfile + "*_cpr.fits")):
+        for f in sorted(glob.glob(obsfile + "*_crf.fits")):
             # example to match: jw04793001001_02101_00001_nrcb1_crf.fits
-            m = re.search(r"jw(\d+)_(\d+)_(\d+)_(\d+)_(nrcb\d+)", f) 
+            m = re.search(r"(jw\d+_\d+_\d+_nrcb\d+)", f)
             if m:
                 n_scas += 1
-                this_obsfile = str(m.group(0))
+                this_obsfile = str(m.group(1))
                 all_scas.append(this_obsfile)
                 this_file = fits.open(f, memmap=True)
                 this_wcs = wcs.WCS(this_file["SCI"].header)
@@ -977,9 +979,9 @@ def get_effective_gain(sca, tempdir=tempdir, indata_type="fits"):
         obsid = m.group(1)
         scaid = m.group(2)
     elif indata_type == "jwst":
-        m = re.search(r"jw(\d+)_(\d+)_(\d+)_(\d+)_(nrcb\d+)", sca)
-        obsid = m.group(1) + "_" + m.group(2) + "_" + m.group(3) + "_" + m.group(4)
-        scaid = m.group(5)
+        m = re.search(r"(jw\d+_\d+_\d+)_(nrcb\d+)", sca)
+        obsid = m.group(1)
+        scaid = m.group(2)
 
     g_eff = np.memmap(
         tempdir + obsid + "_" + scaid + "_geff.dat",
@@ -1019,9 +1021,9 @@ def get_ids(sca, indata_type="fits"):
         obsid = m.group(1)
         scaid = m.group(2)
     elif indata_type == "jwst":
-        m = re.search(r"jw(\d+)_(\d+)_(\d+)_(\d+)_(nrcb\d+)", sca) 
-        obsid = m.group(1) + "_" + m.group(2) + "_" + m.group(3) + "_" + m.group(4)
-        scaid = m.group(5)
+        m = re.search(r"(jw\d+_\d+_\d+)_(nrcb\d+)", sca)
+        obsid = m.group(1)
+        scaid = m.group(2)
     return obsid, scaid
 
 
@@ -1123,7 +1125,17 @@ def get_neighbors(scalist, ov_mat, overlap_thresh=0.1):
 
 
 def residual_function(
-    psi, f_prime, scalist, wcslist, neighbors, thresh, workers, cfg, extrareturn=False, of=None, indata_type="fits"
+    psi,
+    f_prime,
+    scalist,
+    wcslist,
+    neighbors,
+    thresh,
+    workers,
+    cfg,
+    extrareturn=False,
+    of=None,
+    indata_type="fits",
 ):
     """
     Calculate the residual image, = grad(epsilon)
@@ -1209,7 +1221,9 @@ def residual_function(
     return resids
 
 
-def residual_function_single(k, sca_a, wcs_a, psi_a, f_prime, scalist, neighbors, thresh, cfg, of=None, indata_type="fits"):
+def residual_function_single(
+    k, sca_a, wcs_a, psi_a, f_prime, scalist, neighbors, thresh, cfg, of=None, indata_type="fits"
+):
     """
     Calculate the residual for a single SCA image
 
@@ -1249,7 +1263,7 @@ def residual_function_single(k, sca_a, wcs_a, psi_a, f_prime, scalist, neighbors
         for each SCA j that overlaps with this one
     """
     # Go and get the WCS object for image A
-    obsid_A, scaid_A = get_ids(sca_a)
+    obsid_A, scaid_A = get_ids(sca_a, indata_type=indata_type)
 
     # Calculate and then transpose the gradient of I_A-J_A
     gradient_interpolated = f_prime(psi_a, thresh) if thresh is not None else f_prime(psi_a)
@@ -1257,7 +1271,7 @@ def residual_function_single(k, sca_a, wcs_a, psi_a, f_prime, scalist, neighbors
     term_1 = transpose_par(gradient_interpolated)
 
     # Retrieve the effective gain and N_eff to normalize the gradient before transposing back
-    g_eff_A, n_eff_A = get_effective_gain(sca_a)
+    g_eff_A, n_eff_A = get_effective_gain(sca_a, indata_type=indata_type)
 
     # Avoid dividing by zero
     valid_mask = n_eff_A != 0
@@ -1271,7 +1285,7 @@ def residual_function_single(k, sca_a, wcs_a, psi_a, f_prime, scalist, neighbors
 
     for j in neighbors[k]:
         sca_b = scalist[j]
-        obsid_B, scaid_B = get_ids(sca_b)
+        obsid_B, scaid_B = get_ids(sca_b, indata_type=indata_type)
 
         I_B = Sca_img(obsid_B, scaid_B, cfg, indata_type=indata_type)  # Initialize image B
         gradient_original = np.zeros(I_B.shape)
@@ -1326,13 +1340,7 @@ def cost_function_single(j, sca_a, p, f, scalist, neighbors, thresh, cfg, of=Non
     local_epsilon : Float
         the cost function value for this SCA
     """
-    if indata_type == "fits":
-        m = re.search(r"_(\d+)_(\d+)", sca_a)
-        obsid_A, scaid_A = m.group(1), m.group(2)
-    elif indata_type == "jwst":
-        m = re.search(r"jw(\d+)_(\d+)_(\d+)_(\d+)_(nrcb\d+)", sca_a)
-        obsid_A = m.group(1) + "_" + m.group(2) + "_" + m.group(3) + "_" + m.group(4)
-        scaid_A = m.group(5)
+    obsid_A, scaid_A = get_ids(sca_a, indata_type=indata_type)
 
     I_A = Sca_img(obsid_A, scaid_A, cfg, indata_type=indata_type)
     I_A.subtract_parameters(p, j)
@@ -1380,7 +1388,9 @@ def cost_function_single(j, sca_a, p, f, scalist, neighbors, thresh, cfg, of=Non
     return j, psi, local_epsilon
 
 
-def cost_function(p, f, thresh, workers, scalist, neighbors, cfg, tempdir=tempdir, of=None, indata_type="fits"):
+def cost_function(
+    p, f, thresh, workers, scalist, neighbors, cfg, tempdir=tempdir, of=None, indata_type="fits"
+):
     """
     Calculate the cost function with the current de-striping parameters.
 
@@ -1427,7 +1437,19 @@ def cost_function(p, f, thresh, workers, scalist, neighbors, cfg, tempdir=tempdi
 
     with ProcessPoolExecutor(max_workers=workers) as executor:
         futures = [
-            executor.submit(cost_function_single, j, sca_a, p, f, scalist, neighbors, thresh, cfg, of=of, indata_type=indata_type)
+            executor.submit(
+                cost_function_single,
+                j,
+                sca_a,
+                p,
+                f,
+                scalist,
+                neighbors,
+                thresh,
+                cfg,
+                of=of,
+                indata_type=indata_type,
+            )
             for j, sca_a in enumerate(scalist)
         ]
 
@@ -1553,15 +1575,23 @@ def linear_search_general(
     write_to_file("### Calculating min and max epsilon and cost", of)
     max_params = p.params + alpha_max * direction
     max_p.params = max_params
-    max_epsilon, max_psi = cost_function(max_p, f, thresh, workers, scalist, neighbors, cfg, indata_type=indata_type)
-    max_resids = residual_function(max_psi, f_prime, scalist, wcslist, neighbors, thresh, workers, cfg, indata_type=indata_type)
+    max_epsilon, max_psi = cost_function(
+        max_p, f, thresh, workers, scalist, neighbors, cfg, indata_type=indata_type
+    )
+    max_resids = residual_function(
+        max_psi, f_prime, scalist, wcslist, neighbors, thresh, workers, cfg, indata_type=indata_type
+    )
     del max_psi
     d_cost_max = np.sum(max_resids * direction)
 
     min_params = p.params + alpha_min * direction
     min_p.params = min_params
-    min_epsilon, min_psi = cost_function(min_p, f, thresh, workers, scalist, neighbors, cfg, indata_type=indata_type)
-    min_resids = residual_function(min_psi, f_prime, scalist, wcslist, neighbors, thresh, workers, cfg, indata_type=indata_type)
+    min_epsilon, min_psi = cost_function(
+        min_p, f, thresh, workers, scalist, neighbors, cfg, indata_type=indata_type
+    )
+    min_resids = residual_function(
+        min_psi, f_prime, scalist, wcslist, neighbors, thresh, workers, cfg, indata_type=indata_type
+    )
     del min_psi
     d_cost_min = np.sum(min_resids * direction)
 
@@ -1598,7 +1628,9 @@ def linear_search_general(
         working_params = p.params + alpha_test * direction
         working_p.params = working_params
 
-        working_epsilon, working_psi = cost_function(working_p, f, thresh, workers, scalist, neighbors, cfg, indata_type=indata_type)
+        working_epsilon, working_psi = cost_function(
+            working_p, f, thresh, workers, scalist, neighbors, cfg, indata_type=indata_type
+        )
         print(f"Global elapsed t = {(time.time()-t0_global)/60:8.1f}")
         working_resids = residual_function(
             working_psi, f_prime, scalist, wcslist, neighbors, thresh, workers, cfg, indata_type=indata_type
@@ -1648,7 +1680,19 @@ def linear_search_general(
 
 
 def linear_search_quadratic(
-    p, direction, f, f_prime, grad_current, thresh, workers, scalist, wcslist, neighbors, cfg, of=None, indata_type="fits"
+    p,
+    direction,
+    f,
+    f_prime,
+    grad_current,
+    thresh,
+    workers,
+    scalist,
+    wcslist,
+    neighbors,
+    cfg,
+    of=None,
+    indata_type="fits",
 ):
     """
     For the quadratic cost function, direct calculation of alpha that minimizes the function
@@ -1712,8 +1756,12 @@ def linear_search_quadratic(
     # Calculate
     trial_params = p.params + alpha_max * direction
     trial_p.params = trial_params
-    trial_epsilon, trial_psi = cost_function(trial_p, f, thresh, workers, scalist, neighbors, cfg, indata_type=indata_type)
-    trial_resids = residual_function(trial_psi, f_prime, scalist, wcslist, neighbors, thresh, workers, cfg, indata_type=indata_type)
+    trial_epsilon, trial_psi = cost_function(
+        trial_p, f, thresh, workers, scalist, neighbors, cfg, indata_type=indata_type
+    )
+    trial_resids = residual_function(
+        trial_psi, f_prime, scalist, wcslist, neighbors, thresh, workers, cfg, indata_type=indata_type
+    )
     del trial_psi, trial_epsilon
 
     alpha_new = (
@@ -1724,7 +1772,9 @@ def linear_search_quadratic(
 
     new_params = p.params + alpha_new * direction
     new_p.params = new_params
-    new_epsilon, new_psi = cost_function(new_p, f, thresh, workers, scalist, neighbors, cfg, indata_type=indata_type)
+    new_epsilon, new_psi = cost_function(
+        new_p, f, thresh, workers, scalist, neighbors, cfg, indata_type=indata_type
+    )
     new_resids = grad_current + (alpha_new / alpha_max) * (trial_resids - grad_current)
     write_to_file(f"(Inside LS) Global elapsed t = {(time.time()-t0_global)/60:8.1f}", of)
     sys.stdout.flush()
@@ -1868,7 +1918,9 @@ def conjugate_gradient(
 
         # Compute the gradient
         if grad is None:
-            grad = residual_function(psi, f_prime, scalist, wcslist, neighbors, thresh, workers, cfg, indata_type=indata_type)
+            grad = residual_function(
+                psi, f_prime, scalist, wcslist, neighbors, thresh, workers, cfg, indata_type=indata_type
+            )
             write_to_file(
                 f"Minutes spent in initial residual function: {(time.time() - t_start_CG_iter) / 60}", of
             )
@@ -1922,7 +1974,19 @@ def conjugate_gradient(
 
         if cost_model == "quadratic":
             p_new, psi_new, grad_new, epsilon_new = linear_search_quadratic(
-                p, direction, f, f_prime, grad, thresh, workers, scalist, wcslist, neighbors, cfg, of=of, indata_type=indata_type
+                p,
+                direction,
+                f,
+                f_prime,
+                grad,
+                thresh,
+                workers,
+                scalist,
+                wcslist,
+                neighbors,
+                cfg,
+                of=of,
+                indata_type=indata_type,
             )
 
         else:
@@ -1942,8 +2006,7 @@ def conjugate_gradient(
                 neighbors,
                 cfg,
                 of=of,
-                indata_type=indata_type
-
+                indata_type=indata_type,
             )
 
         write_to_file(f"Global elapsed t = {(time.time()-t0_global)/60:8.1f}", of)
@@ -2129,7 +2192,7 @@ def main(cfg_file=None, overlaponly=False, of=None):
         write_to_file("Conjugate gradient failed. Restart state saved to cg_restart.pkl\n", of)
 
     for i, sca in enumerate(all_scas):
-        obsid, scaid = get_ids(sca)
+        obsid, scaid = get_ids(sca, indata_type=indata_type)
         this_sca = Sca_img(obsid, scaid, CFG, add_objmask=False, indata_type=indata_type)
         this_param_set = p.forward_par(i)
         ds_image = this_sca.image - this_param_set

--- a/src/pyimcom/imdestripe.py
+++ b/src/pyimcom/imdestripe.py
@@ -118,11 +118,6 @@ t0_global = time.time()  # after imports
 use_output_float = np.float32
 tempdir = str(os.environ["TMPDIR"]) if "TMPDIR" in os.environ else "./"
 
-# For test outputs: set sca=0 to not produce test outputs.
-img_full_output = {"obsid": 670, "scaid": 10}
-if not testoutputs["testing"]:
-    img_full_output = {"obsid": -1, "scaid": -1}  # don't do these big outputs
-
 
 class Cost_models:
     """
@@ -230,6 +225,7 @@ class Sca_img:
                 self.shape = np.shape(self.image)
                 self._file_handle = None
                 self.type = "fits"
+                self.mask_threshold = [0, 0.3] # m, c for object masking
                 file.close()
 
             elif indata_type == "asdf":
@@ -240,6 +236,7 @@ class Sca_img:
                 self.header = None
                 self.shape = np.shape(self.image)
                 self.type = "asdf"
+                self.mask_threshold = [0, 0.3] # m, c for object masking
                 # Note: keep _file_handle open to maintain memmap
             elif indata_type == "jwst":
                 file = fits.open(
@@ -255,6 +252,7 @@ class Sca_img:
                 self.shape = np.shape(self.image)
                 self._file_handle = None
                 self.type = "jwst"
+                self.mask_threshold = [15, 5] # m, c for object masking
                 file.close()
 
         self.obsid = obsid
@@ -304,13 +302,13 @@ class Sca_img:
             self.apply_noise()
 
         if add_objmask:
-            _, object_mask = apply_object_mask(self.image)
             if indata_type == "asdf":
                 self.apply_asdf_mask()
             elif indata_type == "fits":
                 self.apply_permanent_mask()
             elif indata_type == "jwst":
                 self.apply_jwst_mask()
+            _, object_mask = apply_object_mask(self.image, threshold_m=self.mask_threshold[0], threshold_c=self.mask_threshold[1], type=self.type)
             self.mask *= np.logical_not(
                 object_mask
             )  # self.mask = True for good pixels, so set object_mask'ed pixels to False
@@ -727,7 +725,7 @@ def save_fits(image, filename, dir=None, overwrite=True, s=False, header=None, r
                 raise RuntimeError(f"Failed to write {fp} after {retries} attempts. Last error: {e}") from e
 
 
-def apply_object_mask(image, mask=None, threshold_m=0, threshold_c=0.3, inplace=False):
+def apply_object_mask(image, mask=None, threshold_m=0, threshold_c=0.3, inplace=False, type="fits"):
     """
     Apply a bright object mask to an image.
 
@@ -743,6 +741,8 @@ def apply_object_mask(image, mask=None, threshold_m=0, threshold_c=0.3, inplace=
         constant to add to the threshold.
     inplace : Bool
         Whether to modify the input image directly.
+    type : Str
+        Type of the input image. Options: 'fits', 'asdf', 'jwst'. Default: 'fits'
 
     Returns
     --------
@@ -755,7 +755,17 @@ def apply_object_mask(image, mask=None, threshold_m=0, threshold_c=0.3, inplace=
         neighbor_mask = mask
     else:
         median_val = np.median(image)
-        high_value_mask = image >= threshold_m * median_val + threshold_c
+        if type == "jwst":
+            # We need tiered thresholding for JWST data because of vastly different sky scenes.
+            if median_val<0.1:
+                high_value_mask = image >= median_val + threshold_c
+            elif 0.1<median_val<0.4:
+                high_value_mask = image >= threshold_m * median_val + threshold_c
+            else:
+                high_value_mask = image >= 0.5*threshold_m * median_val 
+        else:
+            high_value_mask = image >= threshold_m * median_val + threshold_c
+            
         neighbor_mask = binary_dilation(high_value_mask, structure=np.ones((5, 5), dtype=bool))
 
     if inplace:
@@ -979,7 +989,7 @@ def get_effective_gain(sca, tempdir=tempdir, indata_type="fits"):
         obsid = m.group(1)
         scaid = m.group(2)
     elif indata_type == "jwst":
-        m = re.search(r"(jw\d+_\d+_\d+)_(nrcb\d+)", sca)
+        m = re.search(r"jw(\d+_\d+_\d+)_(nrcb\d+)", sca)
         obsid = m.group(1)
         scaid = m.group(2)
 
@@ -1021,7 +1031,7 @@ def get_ids(sca, indata_type="fits"):
         obsid = m.group(1)
         scaid = m.group(2)
     elif indata_type == "jwst":
-        m = re.search(r"(jw\d+_\d+_\d+)_(nrcb\d+)", sca)
+        m = re.search(r"jw(\d+_\d+_\d+)_(nrcb\d+)", sca)
         obsid = m.group(1)
         scaid = m.group(2)
     return obsid, scaid
@@ -2113,7 +2123,8 @@ def main(cfg_file=None, overlaponly=False, of=None, testing=False):
         Prefix for destriped images. Add f"_{obsid}_{sca}.fits" to get the full file name.
 
     """
-
+    global img_full_output
+    
     CG_models = {"FR", "PR", "HS", "DY"}
 
     if cfg_file is None:
@@ -2123,11 +2134,22 @@ def main(cfg_file=None, overlaponly=False, of=None, testing=False):
         CFG = Config(cfg_file=cfg_file)
     else:
         raise ValueError("Please provide a config file as a command line argument.")
-
-    filter_ = filters[CFG.use_filter]
+    
     outpath = CFG.ds_outpath
-    indata_type = "jwst" if JWST else "fits"
+    if JWST:   
+        indata_type = "jwst" 
+        filter_ = CFG.use_filter
+    else:
+        indata_type = "fits"
+        filter_ = filters[CFG.use_filter]
     if testing: testoutputs["testing"] = True
+
+    # For test outputs: set sca=0 to not produce test outputs.
+    img_full_output = {"obsid": "04793009001_02101_00001", "scaid": "nrcb2"} if JWST else {"obsid": 670, "scaid": 10}
+    if not testoutputs["testing"]:
+        img_full_output = {"obsid": -1, "scaid": -1}  # don't do these big outputs
+
+
 
     # Prior on cost function is not yet implemented
     # if CFG.cost_prior != 0:

--- a/src/pyimcom/imdestripe.py
+++ b/src/pyimcom/imdestripe.py
@@ -2092,7 +2092,7 @@ def conjugate_gradient(
     return p
 
 
-def main(cfg_file=None, overlaponly=False, of=None):
+def main(cfg_file=None, overlaponly=False, of=None, testing=False):
     """
     Main function to run destriping via conjugate gradient descent.
 
@@ -2102,8 +2102,10 @@ def main(cfg_file=None, overlaponly=False, of=None):
         Configuration file (if not provided, reads from command line arguments).
     overlaponly : bool, optional
         Only compute the overlap matrix, then stop.
-    of : str, optional
+    of : str, optionals
         Output file for logging. If None, logs are printed to stdout.
+    testing : bool, optional
+        If True, saves additional diagnostic images and info for testing and validation.
 
     Returns
     -------
@@ -2125,6 +2127,7 @@ def main(cfg_file=None, overlaponly=False, of=None):
     filter_ = filters[CFG.use_filter]
     outpath = CFG.ds_outpath
     indata_type = "jwst" if JWST else "fits"
+    if testing: testoutputs["testing"] = True
 
     # Prior on cost function is not yet implemented
     # if CFG.cost_prior != 0:

--- a/src/pyimcom/imdestripe.py
+++ b/src/pyimcom/imdestripe.py
@@ -237,6 +237,20 @@ class Sca_img:
                 self.header = None
                 self.shape = np.shape(self.image)
                 # Note: keep _file_handle open to maintain memmap
+            elif indata_type=="jwst":
+                file = fits.open(
+                    cfg.ds_obsfile + obsid + "_" + scaid + "_cpr.fits",
+                    memmap=True,
+                ) # ds_obsfile is 'path/to/jw' 
+                # obsid is <ppppp><ooo><vvv>_<gg><s><aa>_<eeeee>
+                # scaid is nrcb<n>
+                image_hdu = "SCI"
+                self.w = wcs.WCS(file[image_hdu].header)
+                self.image = np.copy(file[image_hdu].data).astype(np.float64)
+                self.header = file[image_hdu].header
+                self.shape = np.shape(self.image)
+                self._file_handle = None
+                file.close()
 
         self.obsid = obsid
         self.scaid = scaid
@@ -290,6 +304,8 @@ class Sca_img:
                 self.apply_asdf_mask()
             elif indata_type == "fits":
                 self.apply_permanent_mask()
+            elif indata_type == "jwst":
+                self.apply_jwst_mask()
             self.mask *= np.logical_not(
                 object_mask
             )  # self.mask = True for good pixels, so set object_mask'ed pixels to False
@@ -372,29 +388,22 @@ class Sca_img:
         self.image *= ~mask
         self.mask *= ~mask
 
-    def get_permanent_mask(self):
+    def apply_jwst_mask(self):
         """
-        Apply permanent pixel mask.
-        Updates self.image and self.mask
+        Apply JWST data quality mask. Updates self.image and self.mask
         """
-        pm = fits.open(
-            self.cfg.ds_obsfile
-            + filters[self.cfg.use_filter]
-            + "_"
-            + self.obsid
-            + "_"
-            + self.scaid
-            + ".fits",
-        )["MASK"].data
-        pm_array = np.copy(pm)
-        return pm_array
+        mask = np.where(self.image==np.nan, 0, 1) 
+        self.image *= mask # this will set NaN pixels to 0 in the image, and keep the rest unchanged
+        self.mask *= mask # this will set the mask to 0 for NaN pixels, and keep the rest unchanged
 
     def apply_all_mask(self):
         """
         Apply permanent pixel mask.
         Updates self.image in-place
         """
-        self.image *= self.mask
+        # Multiply by mask but set Nans to zero
+        self.image = np.where(np.isnan(self.image), 0, self.image*self.mask) 
+        # self.image *= self.mask 
 
     def subtract_parameters(self, p, j):
         """

--- a/src/pyimcom/imdestripe.py
+++ b/src/pyimcom/imdestripe.py
@@ -1460,7 +1460,8 @@ def compute_boundary_continuity_penalty(
     penalty = 0.0
 
     write_to_file(
-        f"Computing boundary continuity penalty for {n_col_blocks} column blocks with chunks of size {chunk_width}x{chunk_height} (yielding N chunks per boundary: {n_rows // (4 * chunk_height) } )"
+        f"Computing boundary continuity penalty for {n_col_blocks} column blocks with chunks of size"
+        f" {chunk_width}x{chunk_height} (yielding N chunks per boundary: {n_rows // (4 * chunk_height) } )"
     )
 
     # Loop over each column-block boundary

--- a/src/pyimcom/imdestripe.py
+++ b/src/pyimcom/imdestripe.py
@@ -1416,7 +1416,9 @@ def residual_function_single(
     return k, term_1, term_2_list
 
 
-def compute_boundary_continuity_penalty(destriped_image, mask, amp_cols, col_boundary_const, chunk_width=50, chunk_height=100):
+def compute_boundary_continuity_penalty(
+    destriped_image, mask, amp_cols, col_boundary_const, chunk_width=50, chunk_height=100
+):
     """
     Penalize large discontinuities in the destriped image across amp-width
     boundaries, pushing the final destriped image towards being continuous.
@@ -1457,17 +1459,19 @@ def compute_boundary_continuity_penalty(destriped_image, mask, amp_cols, col_bou
     n_col_blocks = n_cols // amp_cols
     penalty = 0.0
 
-    write_to_file(f"Computing boundary continuity penalty for {n_col_blocks} column blocks with chunks of size {chunk_width}x{chunk_height} (yielding N chunks per boundary: {n_rows // (4 * chunk_height) } )")
+    write_to_file(
+        f"Computing boundary continuity penalty for {n_col_blocks} column blocks with chunks of size {chunk_width}x{chunk_height} (yielding N chunks per boundary: {n_rows // (4 * chunk_height) } )"
+    )
 
     # Loop over each column-block boundary
     for b in range(1, n_col_blocks):
         left_col_lower = b * amp_cols - chunk_width
         right_col_upper = b * amp_cols + chunk_width
-        col_chunk_lower = slice(left_col_lower, b*amp_cols)
-        col_chunk_upper = slice(b*amp_cols, right_col_upper)
+        col_chunk_lower = slice(left_col_lower, b * amp_cols)
+        col_chunk_upper = slice(b * amp_cols, right_col_upper)
 
         # Loop over chunks
-        for chunk_start in range(0, n_rows, 4*chunk_height):
+        for chunk_start in range(0, n_rows, 4 * chunk_height):
             chunk_end = min(chunk_start + chunk_height, n_rows)
             row_chunk = slice(chunk_start, chunk_end)
 

--- a/src/pyimcom/imdestripe.py
+++ b/src/pyimcom/imdestripe.py
@@ -624,7 +624,7 @@ class Parameters:
             raise ValueError(f"Model {cfg.ds_model} not in model_params dictionary.")
         self.model = cfg.ds_model
         self.n_rows = cfg.ds_rows
-        self.n_cols = Settings.sca_nside
+        self.n_cols = getattr(cfg, "sca_nside", Settings.sca_nside)
         self.params_per_row = model_params[self.model]
 
         if cfg.amp_cols is not None and cfg.amp_cols > 0:
@@ -1521,20 +1521,21 @@ def cost_function_single(j, sca_a, p, f, scalist, neighbors, thresh, cfg, of=Non
     local_epsilon : Float
         the cost function value for this SCA
     """
+    full_output = globals().get("img_full_output", {"scaid": 0, "obsid": -1})
     obsid_A, scaid_A = get_ids(sca_a, indata_type=indata_type)
 
     I_A = Sca_img(obsid_A, scaid_A, cfg, indata_type=indata_type)
     I_A.subtract_parameters(p, j)
     I_A.apply_all_mask()
 
-    if img_full_output["scaid"] != 0 and testoutputs["testing"]:
-        example_obs = obsid_A == str(img_full_output["obsid"])
-        example_sca = scaid_A == str(img_full_output["scaid"])
+    if full_output["scaid"] != 0 and testoutputs["testing"]:
+        example_obs = obsid_A == str(full_output["obsid"])
+        example_sca = scaid_A == str(full_output["scaid"])
         if example_obs and example_sca:
             hdu = fits.PrimaryHDU(I_A.image)
             hdu.writeto(
                 testoutputs["test_image_dir"]
-                + f'{img_full_output["obsid"]}_{img_full_output["scaid"]}_I_A_sub_masked.fits',
+                + f'{full_output["obsid"]}_{full_output["scaid"]}_I_A_sub_masked.fits',
                 overwrite=True,
             )
 
@@ -1558,21 +1559,20 @@ def cost_function_single(j, sca_a, p, f, scalist, neighbors, thresh, cfg, of=Non
             of,
         )
 
-    if img_full_output["scaid"] != 0 and testoutputs["testing"] and example_obs and example_sca:
+    if full_output["scaid"] != 0 and testoutputs["testing"] and example_obs and example_sca:
         hdu = fits.PrimaryHDU(J_A_image * J_A_mask)
         hdu.writeto(
-            testoutputs["test_image_dir"]
-            + f'{img_full_output["obsid"]}_{img_full_output["scaid"]}_J_A_masked.fits',
+            testoutputs["test_image_dir"] + f'{full_output["obsid"]}_{full_output["scaid"]}_J_A_masked.fits',
             overwrite=True,
         )
 
         hdu = fits.PrimaryHDU(psi)
         hdu.writeto(
-            testoutputs["test_image_dir"] + f'{img_full_output["obsid"]}_{img_full_output["scaid"]}_Psi.fits',
+            testoutputs["test_image_dir"] + f'{full_output["obsid"]}_{full_output["scaid"]}_Psi.fits',
             overwrite=True,
         )
 
-        write_to_file(f"Sample stats for SCA {img_full_output}:", of)
+        write_to_file(f"Sample stats for SCA {full_output}:", of)
         write_to_file(f"Image A mean: {np.mean(I_A.image)}", of)
         write_to_file(f"Image B mean: {np.mean(J_A_image)}", of)
         write_to_file(f"Psi mean: {np.mean(psi)}", of)

--- a/src/pyimcom/imdestripe.py
+++ b/src/pyimcom/imdestripe.py
@@ -1416,15 +1416,13 @@ def residual_function_single(
     return k, term_1, term_2_list
 
 
-def compute_boundary_continuity_penalty(destriped_image, mask, amp_cols, col_boundary_const):
+def compute_boundary_continuity_penalty(destriped_image, mask, amp_cols, col_boundary_const, chunk_width=50, chunk_height=100):
     """
     Penalize large discontinuities in the destriped image across amp-width
-    boundaries, making the final destriped image continuous even if individual parameters
-    are discontinuous.
+    boundaries, pushing the final destriped image towards being continuous.
 
-    The discontinuity is measured as the median absolute difference in destriped values
-    across boundaries, computed over non-masked pixels in chunks of ~100 rows.
-    Using the median makes the penalty robust to pixel-level noise and masked regions.
+    The discontinuity is measured as the mean absolute difference in destriped values
+    across boundaries, computed over non-masked pixels in chunks of 100 rows x 100 columns (50 on each side).
 
     Parameters
     ----------
@@ -1436,6 +1434,12 @@ def compute_boundary_continuity_penalty(destriped_image, mask, amp_cols, col_bou
         Column-block width. If None or <= 0, no penalty.
     col_boundary_const : int
         Strength of the column boundary penalty. If <= 0, no penalty.
+    chunk_width : int
+        HALF width of the chunks to consider for the penalty. Mean is over this many cols on each side.
+        (Default: 50)
+    chunk_height : int
+        Height of the chunks to consider for the penalty. This is a number of rows.
+        (Default: 100)
 
     Returns
     -------
@@ -1451,36 +1455,37 @@ def compute_boundary_continuity_penalty(destriped_image, mask, amp_cols, col_bou
 
     n_rows, n_cols = destriped_image.shape
     n_col_blocks = n_cols // amp_cols
-    chunk_size = 100  # ~100 rows per chunk for robustness
-
     penalty = 0.0
+
+    write_to_file(f"Computing boundary continuity penalty for {n_col_blocks} column blocks with chunks of size {chunk_width}x{chunk_height} (yielding N chunks per boundary: {n_rows // (4 * chunk_height) } )")
 
     # Loop over each column-block boundary
     for b in range(1, n_col_blocks):
-        left_col_idx = b * amp_cols - 1
-        right_col_idx = b * amp_cols
+        left_col_lower = b * amp_cols - chunk_width
+        right_col_upper = b * amp_cols + chunk_width
+        col_chunk_lower = slice(left_col_lower, b*amp_cols)
+        col_chunk_upper = slice(b*amp_cols, right_col_upper)
 
-        # Loop over row chunks
-        for chunk_start in range(0, n_rows, chunk_size):
-            chunk_end = min(chunk_start + chunk_size, n_rows)
-            chunk_rows = slice(chunk_start, chunk_end)
+        # Loop over chunks
+        for chunk_start in range(0, n_rows, 4*chunk_height):
+            chunk_end = min(chunk_start + chunk_height, n_rows)
+            row_chunk = slice(chunk_start, chunk_end)
 
             # Extract left and right columns for this chunk
-            left_vals = destriped_image[chunk_rows, left_col_idx]
-            right_vals = destriped_image[chunk_rows, right_col_idx]
-            left_mask = mask[chunk_rows, left_col_idx]
-            right_mask = mask[chunk_rows, right_col_idx]
+            left_vals = destriped_image[row_chunk, col_chunk_lower]
+            right_vals = destriped_image[row_chunk, col_chunk_upper]
+            left_mask = mask[row_chunk, col_chunk_lower]
+            right_mask = mask[row_chunk, col_chunk_upper]
 
-            # Only include pixels where both sides are unmasked
-            valid = left_mask & right_mask
+            # Compute the means of the left and right chunks, but only count pixels that are nonzero
+            left_mean = np.mean(left_vals[left_mask])
+            right_mean = np.mean(right_vals[right_mask])
 
-            if np.any(valid):
-                # Compute discontinuities for valid pixels only
-                discontinuities = left_vals[valid] - right_vals[valid]
-                # Use median discontinuity to be robust to outliers
-                median_disc = np.median(discontinuities)
-                # Square and accumulate (penalizes both positive and negative discontinuities equally)
-                penalty += median_disc**2
+            # Compute the difference between the means
+            mean_diff = left_mean - right_mean
+
+            # Square and accumulate (penalizes both positive and negative differences equally)
+            penalty += mean_diff**2
 
     return lambda_reg * penalty
 
@@ -1553,13 +1558,13 @@ def cost_function_single(j, sca_a, p, f, scalist, neighbors, thresh, cfg, of=Non
             I_A.image, I_A.mask, cfg.amp_cols, cfg.col_boundary_const
         )
         local_epsilon += boundary_penalty
+
+    if full_output["scaid"] != 0 and testoutputs["testing"] and example_obs and example_sca:
         write_to_file(
             f"SCA {j}: boundary continuity penalty = {boundary_penalty:.2e}, "
             f"total cost = {local_epsilon:.2e}",
             of,
         )
-
-    if full_output["scaid"] != 0 and testoutputs["testing"] and example_obs and example_sca:
         hdu = fits.PrimaryHDU(J_A_image * J_A_mask)
         hdu.writeto(
             testoutputs["test_image_dir"] + f'{full_output["obsid"]}_{full_output["scaid"]}_J_A_masked.fits',

--- a/src/pyimcom/imdestripe.py
+++ b/src/pyimcom/imdestripe.py
@@ -118,6 +118,11 @@ t0_global = time.time()  # after imports
 use_output_float = np.float32
 tempdir = str(os.environ["TMPDIR"]) if "TMPDIR" in os.environ else "./"
 
+# For test outputs: set sca=0 to not produce test outputs.
+img_full_output = {"obsid": 670, "scaid": 10}
+if not testoutputs["testing"]:
+    img_full_output = {"obsid": -1, "scaid": -1}  # don't do these big outputs
+
 
 class Cost_models:
     """

--- a/tests/pyimcom/test_imdestripe.py
+++ b/tests/pyimcom/test_imdestripe.py
@@ -70,6 +70,10 @@ class MinimalConfig:
         self.gaindir = False
         self.hub_thresh = 1.0
         self.ds_restart = None
+        # amplitude parameters so that this runs with new JWST destripe
+        self.col_pars = [None, 0.0]
+        self.amp_cols = self.col_pars[0]
+        self.col_boundary_const = self.col_pars[1]
 
 
 def create_test_config(ds_rows=100, ds_model="constant", cost_model="quadratic"):

--- a/tests/pyimcom/test_imdestripe.py
+++ b/tests/pyimcom/test_imdestripe.py
@@ -56,6 +56,7 @@ class MinimalConfig:
 
     def __init__(self, ds_rows=100, ds_model="constant", cost_model="quadratic"):
         self.ds_rows = ds_rows
+        self.sca_nside = ds_rows
         self.ds_model = ds_model
         self.cost_model = cost_model
         self.cg_model = "PR"


### PR DESCRIPTION
## Change Description

This pull request introduces support for JWST NIRCam instrument parameters alongside the existing Roman WFI parameters in the configuration system. It adds a method for switching settings to JWST-specific values and  incorporates logic for instrument selection via an environment variable. 
This PR also includes expanded configuration options related to amplifier columns, so that the destriping model can include column offsets as well as the standard row offset model.

## Solution Description

**JWST NIRCam Support:**
* Added a `jwst` class method to the `Settings` class for updating configuration parameters to those appropriate for JWST NIRCam, including filter lists and pixel scales. This method makes it easier to switch between Roman WFI and JWST NIRCam settings as needed.
* Introduced logic to detect the instrument (JWST NIRCam vs. Roman WFI) using the `INSTRUMENT` environment variable, defaulting to WFI if not set.

**Column-wise Offset Support**
* Added new configuration parameters (`col_pars`, `amp_cols`, `col_boundary_const`) to the `Config` class and updated the `_from_dict` method to support these, enabling more flexible handling of amplifier column settings. [[1]](diffhunk://#diff-2d9b3dd9b0bbd084648686165cc1010201b7f22aaf170d4c35c6f7b5b642c3e8R344-R346) [[2]](diffhunk://#diff-2d9b3dd9b0bbd084648686165cc1010201b7f22aaf170d4c35c6f7b5b642c3e8R549-R551)


## Code Quality
- [ ] I have read the Contribution Guide
- [ ] My code follows the code style of this project
- [ ] My code builds (or compiles) cleanly without any errors or warnings
- [ ] My code contains relevant comments and necessary documentation

## Project-Specific Pull Request Checklists
<!--- Please only use the checklist that apply to your change type(s) -->

### Bug Fix Checklist
- [ ] My fix includes a new test that breaks as a result of the bug (if possible)
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)

### New Feature Checklist
- [ ] I have added or updated the docstrings associated with my feature using the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] I have updated the tutorial to highlight my new feature (if appropriate)
- [ ] I have added unit/End-to-End (E2E) test cases to cover my new feature
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)

### Documentation Change Checklist
- [ ] Any updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)

### Build/CI Change Checklist
- [ ] If required or optional dependencies have changed (including version numbers), I have updated the README to reflect this
- [ ] If this is a new CI setup, I have added the associated badge to the README

<!-- ### Version Change Checklist [For Future Use] -->

### Other Change Checklist
- [ ] Any new or updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to highlight my new feature (if appropriate)
- [ ] I have added unit/End-to-End (E2E) test cases to cover any changes
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)
