### PR TITLE
sign fix in coadd.py

### DIFF
--- a/src/pyimcom/analysis.py
+++ b/src/pyimcom/analysis.py
@@ -373,7 +373,7 @@ class OutImage:
         if not data_loaded:
             self.hdu_list = ReadFile(self.fpath)
 
-        coef = int(self.hdu_list[outmap].header.comments["UNIT"].partition("*")[0])
+        coef = 1.0 / HDU_to_bels(self.hdu_list[outmap])
         slice_ = np.s_[j_out] if j_out is not None else np.s_[:]
         data = np.power(10.0, self.hdu_list[outmap].data[slice_] / coef).astype(np.float32)
 

--- a/src/pyimcom/analysis.py
+++ b/src/pyimcom/analysis.py
@@ -910,8 +910,8 @@ class StarsAnal:
         map_ = f[0].data[0, use_slice, :, :]
         wt = np.sum(np.where(f["INWEIGHT"].data[0, :, :, :] > 0.01, 1, 0), axis=0)
         fmap = (
-            f["FIDELITY"].data[0, :, :].astype(np.float32) * HDU_to_bels(f["FIDELITY"]) / 0.1
-        )  # convert to dB
+            f["FIDELITY"].data[0, :, :].astype(np.float32) * HDU_to_bels(f["FIDELITY"]) / (-0.1)
+        )  # convert to dB, inverse scale
         fmap = np.floor(fmap).astype(np.int16)  # and round to integer
         del f
 

--- a/src/pyimcom/coadd.py
+++ b/src/pyimcom/coadd.py
@@ -2222,7 +2222,7 @@ class Block:
                     np.uint16,
                     my_header,
                     "FIDELITY",
-                    ("0.2mB", "-5000*log10(U/C)"),
+                    ("-0.2mB", "-5000*log10(U/C)"),
                 )
             )
 
@@ -2234,7 +2234,7 @@ class Block:
                     np.int16,
                     my_header,
                     "SIGMA",
-                    ("0.1mB", "-10000*log10(Sigma)"),
+                    ("-0.1mB", "-10000*log10(Sigma)"),
                 )
             )
 
@@ -2246,7 +2246,7 @@ class Block:
                     np.uint16,
                     my_header,
                     "KAPPA",
-                    ("0.2mB", "-5000*log10(kappa)"),
+                    ("-0.2mB", "-5000*log10(kappa)"),
                 )
             )
 

--- a/src/pyimcom/diagnostics/dynrange.py
+++ b/src/pyimcom/diagnostics/dynrange.py
@@ -140,7 +140,7 @@ def gen_dynrange_data(inpath, outstem, rpix_try=50, nblockmax=100):
                 # now extract histogram information
                 try:
                     sigma_ = 10 ** (
-                        -0.5 * HDU_to_bels(f["SIGMA"]) * f["SIGMA"].data[0, bd : n - bd, bd : n - bd]
+                        0.5 * HDU_to_bels(f["SIGMA"]) * f["SIGMA"].data[0, bd : n - bd, bd : n - bd]
                     )  # noise standard deviation in units of input noise
                     for j in range(N_noise):
                         countnoise[j, 1] = countnoise[j, 1] + np.count_nonzero(

--- a/src/pyimcom/diagnostics/outimage_utils/helper.py
+++ b/src/pyimcom/diagnostics/outimage_utils/helper.py
@@ -10,8 +10,8 @@ HDU_to_bels
 
 """
 
-# may need to add more packages here in the future
 import re
+import warnings
 
 import numpy as np
 
@@ -63,6 +63,20 @@ def HDU_to_bels(inhdu):
         Floating version of the unitstring encoded in the FITS header.
         Returns np.nan if no match or unrecognized.
 
+    Notes
+    -----
+    This function checks whether the sign of the UNIT is consistent with the
+    comment. If the UNIT is positive, but the comment starts with a "-", then
+    it flips it. This allows it to read legacy files that had a sign bug in UNIT.
+
     """
 
-    return UNIT_to_bels(inhdu.header["UNIT"])
+    val = UNIT_to_bels(inhdu.header["UNIT"])
+    with warnings.catch_warnings():
+        warnings.simplefilter("once")
+        if val > 0 and "UNIT" in inhdu.header and inhdu.header.comments["UNIT"][0] == "-":
+            val = -val
+            warnings.warn(
+                "This is a legacy file with an incorrect - sign in the header ... fixing ...", RuntimeWarning
+            )
+    return val

--- a/src/pyimcom/diagnostics/starcube_nonoise.py
+++ b/src/pyimcom/diagnostics/starcube_nonoise.py
@@ -136,8 +136,8 @@ def gen_starcube_nonoise(infile_fcn, outstem, nblockmax=100):
                 map = f[0].data[0, use_slice, :, :]
                 wt = np.sum(np.where(f["INWEIGHT"].data[0, :, :, :] > 0.01, 1, 0), axis=0)
                 fmap = (
-                    f["FIDELITY"].data[0, :, :].astype(np.float32) * HDU_to_bels(f["FIDELITY"]) / 0.1
-                )  # convert to dB
+                    f["FIDELITY"].data[0, :, :].astype(np.float32) * HDU_to_bels(f["FIDELITY"]) / (-0.1)
+                )  # convert to dB, inverse scale
                 fmap = np.floor(fmap).astype(np.int16)  # and round to integer
                 for fy in range(81):
                     fhist[fy] += np.count_nonzero(fmap[bdpad:-bdpad, bdpad:-bdpad] == fy)

--- a/src/pyimcom/meta/distortimage.py
+++ b/src/pyimcom/meta/distortimage.py
@@ -277,7 +277,7 @@ class MetaMosaic:
 
         """
 
-        self.in_mask = np.logical_or(self.in_noise < noisemax, self.in_mask)
+        self.in_mask = np.logical_or(self.in_noise > noisemax, self.in_mask)
 
     def mask_caps(self, ra, dec, radius):
         """

--- a/src/pyimcom/meta/distortimage.py
+++ b/src/pyimcom/meta/distortimage.py
@@ -197,7 +197,7 @@ class MetaMosaic:
                         self.in_fidelity[symin + cy : symax + cy, sxmin + cx : sxmax + cx] = (
                             f["FIDELITY"].data[0, symin:symax, sxmin:sxmax].astype(np.float32)
                             * HDU_to_bels(f["FIDELITY"])
-                            / 0.1
+                            / (-0.1)
                         )
                         # noise, converted to dB
                         self.in_noise[symin + cy : symax + cy, sxmin + cx : sxmax + cx] = (


### PR DESCRIPTION
This PR will address #115.

The immediate issue is fixing the sign error in the output headers. I tracked the dependences from the `HDU_to_bels` function that uses that.

There is also a question of what we want to do with the 5 deg^2 legacy files that have this bug; my proposal is to check for the inconsistency in the file and correct the sign (with a warning) if it detects a problem.