### PR TITLE
removed useless time print + reduce memory footprint

### DIFF
--- a/docs/splitpsf_README.rst
+++ b/docs/splitpsf_README.rst
@@ -121,7 +121,7 @@ Re-insertion into PyIMCOM
 
 The subtracted images are re-inserted as the cached files by the command:
 
-.. code-block:: python
+.. code-block:: bash
 
   python3 -m pyimcom.splitpsf.update_cube config.json
 

--- a/docs/splitpsf_README.rst
+++ b/docs/splitpsf_README.rst
@@ -34,7 +34,9 @@ An example workflow script, using perl + slurm, is in `writejob_example.pl <../s
 
 7. `Write report <diagnostics_README.rst>`_
 
-The perl script can be run on the Ohio Supercomputer Center using the format::
+The perl script can be run on the Ohio Supercomputer Center using the format:
+
+.. code-block:: bash
 
   perl writejobs_example.pl $ACCOUNT $CONFIGURATION $LOGFILETAG $SCRIPTTAG
   # $ACCOUNT       = the account name you want to use
@@ -89,11 +91,20 @@ Each of these HDUs are a 3D array (Legendre cube), with the number of slices cor
 The iteration step
 ==================
 
-The iteration step can be run as a module::
+The iteration step can be run on a parallel system as:
 
-  python3 -m pyimcom.splitpsf.imsubtract config.json 14
+.. code-block:: python
 
-to run all images from SCA 14. You will need to run this 18 times (once for each SCA) to make sure all the images have been observed.
+  import os
+  from pyimcom.splitpsf.imsubtract_wrapper import run_imsubtract_all
+
+  run_imsubtract_all(config_file, workers=36, fft_workers=4, mmap=os.getenv("TMPDIR"))
+
+where ``config_file`` is passed as a string (file location); ``workers=36`` means that 36 SCAs will be done at once; and ``fft_workers`` means 4 workers are assigned to the 2D FFTs (the most computationally intensive step).
+
+Memory mapping is highly recommended, but you should use the on-node storage on your HPC system; if you are on a system where the on-node storage for your job is given by the ``$TMPDIR`` environment variable, the call listed above will work. If you are on a different system, refer to your HPC system's documentation on how to access a temporary directory unique to your job.
+
+**Note**: This replaces the legacy method of calling `pyimcom.splitpsf.imsubtract` as a module.
 
 The ``pyimcom.splitpsf.imsubtract.run_imsubtract`` function controls all the mechanics of running the code. Its format is::
 
@@ -108,7 +119,9 @@ The "subtracted" images are written to ``f"{cfgdata.inlayercache}_{obsid:08d}_{s
 Re-insertion into PyIMCOM
 =========================
 
-The subtracted images are re-inserted as the cached files by the command::
+The subtracted images are re-inserted as the cached files by the command:
+
+.. code-block:: python
 
   python3 -m pyimcom.splitpsf.update_cube config.json
 

--- a/src/pyimcom/splitpsf/imsubtract.py
+++ b/src/pyimcom/splitpsf/imsubtract.py
@@ -117,6 +117,8 @@ def fftconvolve_multi(in1, in2, out, mode="full", nb=4, workers=None, verbose=Fa
         dy = ytop - ybottom
         in2_ = np.zeros((leny, lenx))
         in2_[: dy + s1y - 1, :s2x] = in2[ybottom : ytop + s1y - 1, :]
+        if not np.any(in2_):
+            continue  # no point in doing FFTs if we're off the edge of the mosaic and this is all zeros
         in2_ft = rfft2(in2_, workers=workers, overwrite_x=True)
         del in2_  # corrupted, remove
         in2_ft *= in1_ft
@@ -129,15 +131,15 @@ def fftconvolve_multi(in1, in2, out, mode="full", nb=4, workers=None, verbose=Fa
         # B = fftconvolve(in1, in2[ybottom : ytop + s1y - 1, :], mode="valid")
         # print(np.shape(A), np.shape(B))
         # print(np.amax(np.abs(A)), np.amax(np.abs(B)), np.amax(np.abs(A-B)))
-        print(
-            f"t = {time.time()-t0:6.3f} s, j={j} shape =",
-            (leny, lenx),
-            "ft =",
-            np.shape(in1_ft),
-            "workers =",
-            workers,
-        )
-        sys.stdout.flush()
+        if verbose:
+            print(
+                f"t = {time.time()-t0:6.3f} s, j={j} shape =",
+                (leny, lenx),
+                "ft =",
+                np.shape(in1_ft),
+                "workers =",
+                workers,
+            )
 
     del in1_ft
     gc.collect()

--- a/src/pyimcom/splitpsf/imsubtract.py
+++ b/src/pyimcom/splitpsf/imsubtract.py
@@ -188,7 +188,7 @@ def pltshow(plt, display, pars={}):
         plt.savefig(display + f"_{obsid}_{sca}_{ix:02d}_{iy:02d}.png")
 
 
-def get_wcs(cachefile, use_float32=True, niter=2):
+def get_wcs(cachefile, use_float32=False, niter=3):
     """
     Gets the WCS from a cached FITS file.
 

--- a/src/pyimcom/splitpsf/imsubtract.py
+++ b/src/pyimcom/splitpsf/imsubtract.py
@@ -83,8 +83,8 @@ def fftconvolve_multi(in1, in2, out, mode="full", nb=4, workers=None, verbose=Fa
 
     t0 = time.time()
 
-    # if we're not using valid, or not in 2D, use standard fftconvolve
-    if mode != "valid" or len(np.shape(in1)) != 2:
+    # if we're not using valid, or not in 2D, or invalid band number, use standard fftconvolve
+    if mode != "valid" or len(np.shape(in1)) != 2 or nb < 1:
         out += fftconvolve(in1, in2, mode=mode)
         return
 
@@ -100,10 +100,7 @@ def fftconvolve_multi(in1, in2, out, mode="full", nb=4, workers=None, verbose=Fa
         return
 
     # loop over horizontal bands
-    height = (Ly + nb - 1) // nb
-    if height <= s1y:
-        out += fftconvolve(in1, in2, mode=mode)  # also return if the strip is too narrow
-        return
+    height = (Ly + nb - 1) // nb  # note we are guaranteed height > s1y
     lenx = next_fast_len(s1x + s2x)
     leny = next_fast_len(s1y + height)
     in1_ = np.zeros((leny, lenx))
@@ -782,23 +779,13 @@ def run_imsubtract(
             return
 
 
+"""Calling program is here.
+
+python3 -m pyimcom.splitpsf.imsubtract  <config> <sca> [<output images>]
+(uses plt.show() if output stem not specified; output image directory is relative to cache file)
+"""
 if __name__ == "__main__":
-    """Calling program is here.
-
-    python3 -m pyimcom.splitpsf.imsubtract  <config> <sca> [<output images>]
-    (uses plt.show() if output stem not specified; output image directory is relative to cache file)
-
-    """
-
-    # get the json file
-    config_file = sys.argv[1]
-
     # get the SCA (0 for all of them)
-    sca = int(sys.argv[2])
-    if sca == 0:
-        sca = None
-
-    display = "/dev/null"
-    if len(sys.argv) > 3:
-        display = sys.argv[3]
-    run_imsubtract(config_file, display=display, scanum=sca, workers=4)
+    sca = None if int(sys.argv[2]) == 0 else int(sys.argv[2])
+    display = sys.argv[3] if len(sys.argv) > 3 else "/dev/null"
+    run_imsubtract(sys.argv[1], display=display, scanum=sca, workers=4)

--- a/src/pyimcom/splitpsf/imsubtract.py
+++ b/src/pyimcom/splitpsf/imsubtract.py
@@ -107,31 +107,39 @@ def fftconvolve_multi(in1, in2, out, mode="full", nb=4, workers=None, verbose=Fa
     lenx = next_fast_len(s1x + s2x)
     leny = next_fast_len(s1y + height)
     in1_ = np.zeros((leny, lenx))
-    in2_ = np.zeros((leny, lenx))
     in1_[:s1y, :s1x] = in1
-    in1_ft = rfft2(in1_, workers=workers)
+    in1_ft = rfft2(in1_, workers=workers, overwrite_x=True)
     del in1_
     for j in range(nb):
         gc.collect()
         ybottom = j * height
         ytop = min((j + 1) * height, Ly)
         dy = ytop - ybottom
-        in2_[:, :] = 0.0
+        in2_ = np.zeros((leny, lenx))
         in2_[: dy + s1y - 1, :s2x] = in2[ybottom : ytop + s1y - 1, :]
-        in2_ft = rfft2(in2_, workers=workers)
+        in2_ft = rfft2(in2_, workers=workers, overwrite_x=True)
+        del in2_  # corrupted, remove
         in2_ft *= in1_ft
         if verbose:
             print("y =", ybottom, ytop, "of Ly =", Ly)
-        out[ybottom:ytop, :] += irfft2(in2_ft, s=(leny, lenx), workers=workers)[
+        out[ybottom:ytop, :] += irfft2(in2_ft, s=(leny, lenx), workers=workers, overwrite_x=True)[
             s1y - 1 : dy + s1y - 1, s1x - 1 : Lx + s1x - 1
         ]
+        del in2_ft  # corrupted, remove
         # B = fftconvolve(in1, in2[ybottom : ytop + s1y - 1, :], mode="valid")
         # print(np.shape(A), np.shape(B))
         # print(np.amax(np.abs(A)), np.amax(np.abs(B)), np.amax(np.abs(A-B)))
-        print(f"t = {time.time()-t0:6.3f} s, shape =", (leny, lenx), "ft =", np.shape(in1_ft))
+        print(
+            f"t = {time.time()-t0:6.3f} s, j={j} shape =",
+            (leny, lenx),
+            "ft =",
+            np.shape(in1_ft),
+            "workers =",
+            workers,
+        )
         sys.stdout.flush()
 
-    del in2_, in1_ft, in2_ft
+    del in1_ft
     gc.collect()
 
 
@@ -635,14 +643,15 @@ def run_imsubtract_single(
 
         # apply convolution to canvas
         for lu in range(Nl):
-            # save first multiplication
-            Hlu = H_canvas * eval_legendre(lu, u_canvas).astype(np.float32)[None, :]
             for lv in range(Nl):
                 print("Convolve", lu, lv)
                 sys.stdout.flush()
+                arr = np.copy(H_canvas)
+                arr *= eval_legendre(lu, u_canvas).astype(np.float32)[None, :]
+                arr *= eval_legendre(lv, u_canvas).astype(np.float32)[:, None]
                 fftconvolve_multi(
                     K[lu + lv * Nl, :, :],
-                    Hlu * eval_legendre(lv, u_canvas).astype(np.float32)[:, None],
+                    arr,
                     KH,
                     mode="valid",
                     nb=6,

--- a/src/pyimcom/splitpsf/imsubtract.py
+++ b/src/pyimcom/splitpsf/imsubtract.py
@@ -647,7 +647,7 @@ def run_imsubtract_single(
 
         # subtract from the input image (using less memory)
         I_img[n, :, :] -= KH[first_index:-first_index:oversamp, first_index:-first_index:oversamp]
-        print(f"Subtracted layer {n+1}/{nlayer}, t = {time.time()-t0:6.2f}", flush=True)
+        print(f"Subtracted layer {n+1}/{nlayer}", flush=True)
 
     # not needed anymore
     del KH

--- a/src/pyimcom/splitpsf/imsubtract.py
+++ b/src/pyimcom/splitpsf/imsubtract.py
@@ -180,7 +180,7 @@ def pltshow(plt, display, pars={}):
         plt.savefig(display + f"_{obsid}_{sca}_{ix:02d}_{iy:02d}.png")
 
 
-def get_wcs(cachefile):
+def get_wcs(cachefile, use_float32=True, niter=2):
     """
     Gets the WCS from a cached FITS file.
 
@@ -190,6 +190,10 @@ def get_wcs(cachefile):
     ----------
     cachefile : str
         Name of the cached file.
+    use_float32 : bool, optional
+        Whether to represent the WCS error map in float32.
+    niter : int, optional
+        Number of iterations for WCS error map.
 
     Returns
     -------
@@ -201,8 +205,8 @@ def get_wcs(cachefile):
     with fits.open(cachefile) as hdul:
         if "WCSTYPE" in hdul[1].header and hdul[1].header["WCSTYPE"][:4].lower() == "gwcs":
             with asdf.open(cachefile[:-5] + "_wcs.asdf") as f2:
-                return PyIMCOM_WCS(f2["wcs"])
-        return PyIMCOM_WCS(hdul["SCIWCS"].header)
+                return PyIMCOM_WCS(f2["wcs"], use_float32=use_float32, niter=niter)
+        return PyIMCOM_WCS(hdul["SCIWCS"].header, use_float32=use_float32, niter=niter)
 
 
 def get_wcs_from_infile(infile):

--- a/src/pyimcom/splitpsf/imsubtract_wrapper.py
+++ b/src/pyimcom/splitpsf/imsubtract_wrapper.py
@@ -9,7 +9,9 @@ from ..config import Config
 from .imsubtract import run_imsubtract_single
 
 
-def run_imsubtract_all(cfg_file, workers=4, max_imgs=None, display=None, local_output=False, mmap=None):
+def run_imsubtract_all(
+    cfg_file, workers=4, fft_workers=None, max_imgs=None, display=None, local_output=False, mmap=None
+):
     """
     Main routine to run imsubtract on all images in the cache.
 
@@ -19,6 +21,8 @@ def run_imsubtract_all(cfg_file, workers=4, max_imgs=None, display=None, local_o
         Path to the config file.
     workers: int, optional
         Number of workers to use for parallel processing. Default is 4.
+    fft_workers: int, optional
+        Number of workers to use for FFT parallelism (if requested).
     max_imgs: int, optional
         If provided, does computations for a maximum number of SCAs. Most users will
         want the default of None; this is provided mainly for testing.
@@ -80,7 +84,7 @@ def run_imsubtract_all(cfg_file, workers=4, max_imgs=None, display=None, local_o
                         path,
                         exp,
                         display=display,
-                        fft_workers=None,
+                        fft_workers=fft_workers,
                         local_output=local_output,
                         max_layers=max_imgs,
                         mmap=mmap,

--- a/tests/pyimcom/test_imsubtract.py
+++ b/tests/pyimcom/test_imsubtract.py
@@ -7,7 +7,7 @@ import urllib.request
 import numpy as np
 from astropy.io import fits
 from pyimcom.config import Config
-from pyimcom.splitpsf.imsubtract import fftconvolve_multi, run_imsubtract
+from pyimcom.splitpsf.imsubtract import fftconvolve_multi, pltshow, run_imsubtract
 from pyimcom.splitpsf.imsubtract_wrapper import run_imsubtract_all, run_imsubtract_single
 from pyimcom.splitpsf.splitpsf import SplitPSF, split_psf_to_fits
 from pyimcom.splitpsf.splitpsf_wrapper import split_psf_single
@@ -356,3 +356,24 @@ def test_staticmethods():
     assert np.allclose(arr[6, :], arr[:, 6], rtol=0, atol=1.0e-6)
     for x in [arr[0, 0], arr[0, -1], arr[-1, 0], arr[-1, -1]]:
         assert np.abs(x - u**2) < 1.0e-6
+
+
+def test_pltshow():
+    """Test the other options for pltshow."""
+
+    class _Plt:
+        """Test class to count calls."""
+
+        def __init__(self):
+            self.calls = 0
+
+        def show(self):
+            """Mock show method."""
+            self.calls += 1
+
+    plot = _Plt()
+    assert plot.calls == 0
+    pltshow(plot, None)
+    assert plot.calls == 1
+    pltshow(plot, "/dev/null")
+    assert plot.calls == 1

--- a/tests/pyimcom/test_imsubtract.py
+++ b/tests/pyimcom/test_imsubtract.py
@@ -7,7 +7,7 @@ import urllib.request
 import numpy as np
 from astropy.io import fits
 from pyimcom.config import Config
-from pyimcom.splitpsf.imsubtract import fftconvolve_multi, pltshow, run_imsubtract
+from pyimcom.splitpsf.imsubtract import fftconvolve_multi, get_wcs, pltshow, run_imsubtract
 from pyimcom.splitpsf.imsubtract_wrapper import run_imsubtract_all, run_imsubtract_single
 from pyimcom.splitpsf.splitpsf import SplitPSF, split_psf_to_fits
 from pyimcom.splitpsf.splitpsf_wrapper import split_psf_single
@@ -16,6 +16,35 @@ from scipy.signal import fftconvolve
 PSF_FILE = "https://github.com/Roman-HLIS-Cosmology-PIT/pyimcom/wiki/test-files/psf_test.fits"
 IMSUBTRACT_CONFIG = "https://github.com/Roman-HLIS-Cosmology-PIT/pyimcom/wiki/test-files/imsubtract/test_imsubtract_config.json"
 IMSUBTRACT_INPUT_PATH = "https://github.com/Roman-HLIS-Cosmology-PIT/pyimcom/wiki/test-files/imsubtract"
+
+
+def test_altwcs(tmp_path):
+    """Test reading from SCIWCS."""
+
+    fn = str(tmp_path) + "/altwcs.fits"
+
+    # Make the image (including WCS header)
+    im = fits.ImageHDU(np.zeros((4088, 4088), dtype=np.int16), name="SCIWCS")
+    im.header["CRPIX1"] = 2030
+    im.header["CDELT1"] = -0.0001
+    im.header["CTYPE1"] = "RA---TAN"
+    im.header["CRVAL1"] = 32.0
+    im.header["CUNIT1"] = "deg"
+    im.header["CRPIX2"] = 2030
+    im.header["CDELT2"] = 0.0001
+    im.header["CTYPE2"] = "DEC--TAN"
+    im.header["CRVAL2"] = 15.0
+    im.header["CUNIT2"] = "deg"
+    im.header["EQUINOX"] = 2000.0
+    fits.HDUList([fits.PrimaryHDU(), im]).writeto(fn)
+
+    # get the WCS and clear the old file
+    mywcs = get_wcs(fn)
+    os.remove(fn)
+
+    # now tests on the WCS we got
+    out = mywcs.all_pix2world(np.array([[2029, 1979], [2029, 2029], [2029, 2079]]), 0)
+    assert np.allclose(out, np.array([[32.0, 14.995], [32.0, 15.0], [32.0, 15.005]]))
 
 
 def test_psfsplit(tmp_path):

--- a/tests/pyimcom/test_imsubtract.py
+++ b/tests/pyimcom/test_imsubtract.py
@@ -184,6 +184,12 @@ def test_fftconvolve_multi():
     fftconvolve_multi(arr1, arr2, x2, mode="same")
     assert np.allclose(x1, x2)
 
+    # another test defaulting to fftconvolve
+    x1 = fftconvolve(arr1, arr2, mode="valid")
+    x2 = np.zeros_like(x1)
+    fftconvolve_multi(arr1, arr2, x2, mode="valid", nb=24)
+    assert np.allclose(x1, x2)
+
 
 def test_run_imsubtract_all(tmp_path, config_file=IMSUBTRACT_CONFIG):
     """


### PR DESCRIPTION
This wasn't printing the timing in a useful way, and it also raised an error if the first "input image" you gave it was outside the mosaic since `t0` wasn't initialized properly. So I removed the timing statement.