### PR TITLE
imsubtract speedup

### DIFF
--- a/docs/compress_README.rst
+++ b/docs/compress_README.rst
@@ -1,17 +1,19 @@
 PyIMCOM Compression module
-############################
+##########################
 
 This is the compression module for PyIMCOM outputs. It carries out both lossy and lossless compression operations.
 
 Overview
-**********
+********
 
 There are two fundamental operations: compression and decompression. Logically, compression comes first, but because of the many varied uses of PyIMCOM coadds, we expect more users will need to implement decompression.
 
 Compression
-=============
+===========
 
-Compression operations are carried out with the ``pyimcom.compress.compressutils.CompressedOutput`` class. This is initialized with the name of the file you want to compress. Then various compressions can be done, and the output written to a file. A standard code snippet to compress file ``fname`` and write the output to ``fout`` might be::
+Compression operations are carried out with the ``pyimcom.compress.compressutils.CompressedOutput`` class. This is initialized with the name of the file you want to compress. Then various compressions can be done, and the output written to a file. A standard code snippet to compress file ``fname`` and write the output to ``fout`` might be:
+
+.. code-block:: python
 
    from pyimcom.compress.compressutils import CompressedOutput
    with CompressedOutput(fname) as f:
@@ -38,14 +40,18 @@ Metadata on the compression scheme (needed to decompress the data) is stored in 
 It is recommended to use the ``.cpr.fits.gz`` suffix for a compressed PyIMCOM file, e.g., ``itertest2_F_10_04.fits`` compresses to ``itertest2_F_10_04.cpr.fits.gz``. This is not enforced by ``compressutils``, but some analysis tools recognize compressed files by this convention. The .gzipped file can be unzipped (it is a valid .fits.gz file!) but we expect this won't be common; if you need the uncompressed file, you will probably just decompress it.
 
 Decompression
-==================
+=============
 
-To decompress file ``fout`` to a standard fits file ``frec``, you can run::
+To decompress file ``fout`` to a standard fits file ``frec``, you can run:
+
+.. code-block:: python
 
    from pyimcom.compress.compressutils import ReadFile
    ReadFile(fout).writeto(frec, overwrite=True)
 
-The ``ReadFile`` function returns an ``astropy.io.fits.HDUList`` object, so standard reading of the headers and data is then possible, e.g., you could write::
+The ``ReadFile`` function returns an ``astropy.io.fits.HDUList`` object, so standard reading of the headers and data is then possible, e.g., you could write:
+
+.. code-block:: python
 
    from pyimcom.compress.compressutils import ReadFile
    with ReadFile(fout) as f:
@@ -53,12 +59,12 @@ The ``ReadFile`` function returns an ``astropy.io.fits.HDUList`` object, so stan
       ...
 
 Compression schemes
-*********************
+*******************
 
 There are several compression schemes offered.
 
 I24B
-======
+====
 
 The ``I24B`` compression scheme is the most common. For each layer, it generates two HDUs. The compressed data cube is a 3D ``uint8`` array with a name starting with ``HSHX`` and ending with the hexadecimal code for that layer, e.g., ``HSHX000D`` is the compressed cube for layer 13 (=0XD). There is also a binary table (in this case: ``HSHV000D``) containing values that overflowed the minimum and maximum of the compression range (this is common if, e.g., the image to be compressed is mostly dark sky, but there are a few bright objects, and you don't want to set the compression scale to handle the brightest pixels). The naming scheme will fail and the algorithm will refuse to compress if your layer number goes past 0XFFFF=65535, but in practical cases you won't need that many layers.
 
@@ -126,7 +132,9 @@ These steps are controlled by the following keywords. The default is given, unle
 Tools
 *****
 
-A useful utility for exploring compressed files is ``CompressedOutput.get_compression_dict``. You can call it as::
+A useful utility for exploring compressed files is ``CompressedOutput.get_compression_dict``. You can call it as:
+
+.. code-block:: python
 
    with CompressedOutput(fname) as f:
         cprs_dict = CompressedOutput.get_compression_dict(f, ilayer)

--- a/docs/config_README.rst
+++ b/docs/config_README.rst
@@ -14,49 +14,65 @@ Building a configuration
 PyIMCOM runs are controlled by the ``config.Config`` class.
 There are several ways to set up the configuration:
 
-- The most common way is to read from a JSON file: you may run something like::
+- The most common way is to read from a JSON file: you may run something like:
 
-   cfg = config.Config('my_config.json')
+  .. code-block:: python
 
-- A string that is not a valid path name but could be interpreted as a JSON file can also be used as an argument for the configuration::
+     cfg = config.Config('my_config.json')
 
-   str = '{"OBSFILE": "myobs.fits",\n'
-   str += '"INDATA": ["input_data", "anlsim"],\n'
-   ...
-   str += '"SMAX": 0.5}\n'
-   cfg = config.Config(str)
+- A string that is not a valid path name but could be interpreted as a JSON file can also be used as an argument for the configuration:
 
-- You may also build a configuration file from an IMCOM output file, thus allowing you to reconstruct the configuration that produced it::
+  .. code-block:: python
 
-   cfg = config.Config('test_F_00_00.fits', inmode='block')
+     str = '{"OBSFILE": "myobs.fits",\n'
+     str += '"INDATA": ["input_data", "anlsim"],\n'
+     ...
+     str += '"SMAX": 0.5}\n'
+     cfg = config.Config(str)
+
+- You may also build a configuration file from an IMCOM output file, thus allowing you to reconstruct the configuration that produced it:
+
+  .. code-block:: python
+
+     cfg = config.Config('test_F_00_00.fits', inmode='block')
 
   **Warning**: If you do this, it will reconstruct the *entire* configuration file, including the input and output file paths on the system that generated the file. If you simply want to do this so that the grid spacings, choices of input layers, etc. are accessible from your process, this is fine. But if you are going to run the co-adds, you will want to edit the configuration file so that the file paths correspond to your platform, and (if on the same platform) you don't unintentionally overwrite the outputs.
 
-- You can input a configuration in interactive mode so that the user types the configuration directly in the terminal::
+- You can input a configuration in interactive mode so that the user types the configuration directly in the terminal:
 
-   cfg = config.Config(None)
+  .. code-block:: python
+
+     cfg = config.Config(None)
 
   This is useful for testing, but we don't expect many users will want to do production runs this way.
 
 Editing a configuration
 =======================
 
-A configuration file can be edited by setting an element of the configuration. This might be useful if you want to run a configuration that was the same as that which generated another file, but with the inputs/outputs changed. It is also useful if there are paths that are only determined at run time. For example, at the Ohio Supercomputer Center a job gets access to the local disk on each node but the path name is provided as an environment variable ``$TMPDIR``; in this case, you could set PyIMCOM's temporary file storage via::
+A configuration file can be edited by setting an element of the configuration. This might be useful if you want to run a configuration that was the same as that which generated another file, but with the inputs/outputs changed. It is also useful if there are paths that are only determined at run time. For example, at the Ohio Supercomputer Center a job gets access to the local disk on each node but the path name is provided as an environment variable ``$TMPDIR``; in this case, you could set PyIMCOM's temporary file storage via:
+
+.. code-block:: python
 
    cfg.tempfile = os.getenv('TMPDIR') + '/temp'
 
-If you change the numerical parameters, then you will have to update the derived parameters via a call to the configuration file::
+If you change the numerical parameters, then you will have to update the derived parameters via a call to the configuration file:
+
+.. code-block:: python
 
    cfg()
 
 Saving a configuration
 ======================
 
-The usual way of saving a configuration is with the ``to_file`` method. For example, to save to a file::
+The usual way of saving a configuration is with the ``to_file`` method. For example, to save to a file:
+
+.. code-block:: python
 
    cfg.to_file('my_config.json')
 
-or to save to a string and print to the terminal::
+or to save to a string and print to the terminal:
+
+.. code-block:: python
 
    str = cfg.to_file(None)
    print(str)
@@ -72,9 +88,11 @@ Input files
 This section covers where PyIMCOM looks for input data.
 
 OBSFILE: The table of observations
---------------------------------------------------
+----------------------------------
 
-PyIMCOM needs a table of all observations that it should search over. This is in the format of a FITS binary table. The path to the file is determined by the ``OBSFILE`` keyword::
+PyIMCOM needs a table of all observations that it should search over. This is in the format of a FITS binary table. The path to the file is determined by the ``OBSFILE`` keyword:
+
+.. code-block:: json
 
    "OBSFILE": "/users/PCON0003/cond0007/imcom/pyimcom/anlsim/Roman_WAS_obseq_11_1_23.fits"
 
@@ -92,7 +110,9 @@ The coordinate and filter information is needed for PyIMCOM to select the approp
 INDATA: The input observations
 -----------------------------------
 
-This has two entries containing the directory to find input images and the format::
+This has two entries containing the directory to find input images and the format:
+
+.. code-block:: json
 
    "INDATA": [
       "/fs/scratch/PCON0003/cond0007/anl-run-in-prod/stitch",
@@ -112,7 +132,9 @@ More input formats will be added as needed to support further simulations and Ro
 FILTER: Filter choice
 ---------------------------
 
-This is a simple integer for the filter to coadd::
+This is a simple integer for the filter to coadd:
+
+.. code-block:: json
 
    "FILTER": 4
 
@@ -121,7 +143,9 @@ Convention is 0 (W146), 1 (F184), 2 (H158), 3 (J129), 4 (Y106), 5 (Z087), 6 (R06
 INPSF: Input PSF files
 -----------------------------
 
-This is a list containing a directory, PSF format, and oversampling factor::
+This is a list containing a directory, PSF format, and oversampling factor:
+
+.. code-block:: json
 
     "INPSF": [
        "/fs/scratch/PCON0003/cond0007/anl-run-in-prod/psf_vlarge",
@@ -135,26 +159,39 @@ The valid PSF formats are the same as the input data formats in the `INDATA <IND
 PSFSPLIT: Splitting the PSF\*
 -------------------------------
 
-This keyword is optional (it defaults to ``None``). If provided, it means that the ``pyimcom.splitpsf`` module has been used to split the PSF into long- and short-range parts, which will (eventually) allow for iterative cleaning of the long-range part of the PSF. An example is::
+This keyword is optional (it defaults to ``None``). If provided, it means that the ``pyimcom.splitpsf`` module has been used to split the PSF into long- and short-range parts, which will (eventually) allow for iterative cleaning of the long-range part of the PSF. An example is:
+
+.. code-block:: json
 
     "PSFSPLIT": [6.0, 10.0, 0.01]
 
 This directs ``pyimcom.splitpsf`` to split the PSF so that the short-range part goes smoothly to zero from 6 to 10 pixels, with a regularization parameter for the long-range part of epsilon=0.01.
 
+You can enable running the PSF splitting at lower resolution (faster) by adding a fourth argument, ``true`` (use lowercase):
+
+.. code-block:: json
+
+    "PSFSPLIT": [6.0, 10.0, 0.01, true]
+
+
 PSFINTERP: Interpolation options for the PSF\*
 ----------------------------------------------
 
-This keyword is optional (it defaults to ``D5512``). If provided, it configures the interpolation option for the PSF. ``D5512`` is the default with a 10x10 footprint and is most accurate, but the alternative ``G4460`` with 8x8 footprint is faster and may be sufficient for some applications. To turn this on, you can use::
+This keyword is optional (it defaults to ``D5512``). If provided, it configures the interpolation option for the PSF. ``D5512`` is the default with a 10x10 footprint and is most accurate, but the alternative ``G4460`` with 8x8 footprint is faster and may be sufficient for some applications. To turn this on, you can use:
+
+.. code-block:: json
 
     "PSFINTERP": "G4460"
 
 Masks and layers
-==================
+================
 
 PMASK: Permanent mask\*
-------------------------
+-----------------------
 
-This provides a permanent mask file::
+This provides a permanent mask file:
+
+.. code-block:: json
 
        "PMASK": "/users/PCON0003/cond0007/imcom/pyimcom/anlsim/permanent_mask_ft_231228.fits"
 
@@ -163,9 +200,11 @@ The mask is a FITS file with an integer-type primary HDU consisting of a 18x4088
 If not provided, defaults to no permanent mask.
 
 CMASK: Cosmic ray mask fraction\*
-------------------------------------
+---------------------------------
 
-This specifies a cosmic ray rate per pixel that should be randomly masked::
+This specifies a cosmic ray rate per pixel that should be randomly masked:
+
+.. code-block:: json
 
     "CMASK": 0.00077
 
@@ -178,9 +217,11 @@ The default (0) is to not implement a cosmic ray mask.
 **Comment**: If you are reading simulations from ``romanimpreprocess``, then a mask (including cosmic ray flagging but also anything else specified in ``romanimpreprocess``) is already implemented and stored in the ``*_mask.fits`` file. So in this case it would be duplicative to also implement ``CMASK`` here.
 
 EXTRAINPUT: Additional layers\*
------------------------------------
+-------------------------------
 
-This allows the user to specify a list of additional layers (suites of input images) to run through PyIMCOM with the same coaddition matrix **T**. The "science" layer is layer 0, and if N additional layers are specified then the output FITS images are data cubes with N+1 frames along axis -3. The defailt is no additional layers. An example usage is::
+This allows the user to specify a list of additional layers (suites of input images) to run through PyIMCOM with the same coaddition matrix **T**. The "science" layer is layer 0, and if N additional layers are specified then the output FITS images are data cubes with N+1 frames along axis -3. The defailt is no additional layers. An example usage is:
+
+.. code-block:: json
 
     "EXTRAINPUT": [
         "labnoise",
@@ -238,48 +279,58 @@ The ``pyimcom.layers`` module contains instructions for building each of the dif
 - ``noise``,str : Looks for a specific noise realization with a code written by ``romanimpreprocess``, e.g.: ``noise,RS2Csky1`` will look for the noise layer named ``'RS2Csky1'`` in the ``*_noise.asdf`` file. See the `romanimpreprocess documentation <https://github.com/Roman-HLIS-Cosmology-PIT/romanimpreprocess/tree/main/L1_to_L2>`_ for how to specify the noise layers.
 
 LABNOISETHRESHOLD: Mask based on a laboratory dark\*
--------------------------------------------------------
+----------------------------------------------------
 
 *Optional; only valid if* ``labnoise`` *is in one of the layers.*
 
-This masks a pixel if the laboratory noise field is above some threshold. It is useful for studying the impact of correlated noise but removing large features such as hot pixels. The value specified is the clipping threshold::
+This masks a pixel if the laboratory noise field is above some threshold. It is useful for studying the impact of correlated noise but removing large features such as hot pixels. The value specified is the clipping threshold:
+
+.. code-block:: json
 
    "LABNOISETHRESHOLD": 3.0
 
 What area to coadd
-===================
+==================
 
 This section contains geometrical information on the output mosaic, including the information needed to build the output WCS. The stereographic (``STG``) projection around the mosaic center is used, since it has zero shear distortion and smaller magnification distortion than the commonly used gnomonic (``TAN``) projection.
 
 CTR: Projection center
-------------------------
+----------------------
 
-This gives the RA (first) and Dec (second) of the projection center of the mosaic (in degrees, J2000)::
+This gives the RA (first) and Dec (second) of the projection center of the mosaic (in degrees, J2000):
+
+.. code-block:: json
 
     "CTR": [9.55, -44.1]
 
 LONPOLE: Rotating the mosaic\*
----------------------------------
+------------------------------
 
 *Optional; default is North pointing up*
 
-This is the same as the ``LONPOLE`` FITS keyword (see the `standard <https://ui.adsabs.harvard.edu/abs/2002A%26A...395.1077C/abstract>`_). A value of 180° corresponds to North being up; 270° corresponds to East being up; 0° corresponds to South being up; and 90° corresponds to West being up. Other values are allowed, for example the following has the same center as the case above, but with "up" being 60° East of North::
+This is the same as the ``LONPOLE`` FITS keyword (see the `standard <https://ui.adsabs.harvard.edu/abs/2002A%26A...395.1077C/abstract>`_). A value of 180° corresponds to North being up; 270° corresponds to East being up; 0° corresponds to South being up; and 90° corresponds to West being up. Other values are allowed, for example the following has the same center as the case above, but with "up" being 60° East of North:
+
+.. code-block:: json
 
     "LONPOLE": 240.0
 
 BLOCK: Size of the mosaic
-------------------------------
+-------------------------
 
-The mosaic is a square array of blocks. So to make a 12x12 array, we use::
+The mosaic is a square array of blocks. So to make a 12x12 array, we use:
+
+.. code-block:: json
 
     "BLOCK": 12
 
 The projection center is the same as the mosaic center, so here it would be at the corners of blocks (5,5), (6,5), (5,6), and (6,6).
 
 OUTSIZE: Pixel, postage stamp, and block dimensions
-----------------------------------------------------
+---------------------------------------------------
 
-This controls the size of a block; for example: ::
+This controls the size of a block; for example:
+
+.. code-block:: json
 
     "OUTSIZE": [
         72,
@@ -291,12 +342,14 @@ This case has an output pixel size of 0.0425 arcsec. Each postage stamp to coadd
 **Important**: Because of the way PSF computations are saved (every 2x2 postage stamps), the number of postage stamps per block (72 in the above example) must be even.
 
 More about postage stamps
-==============================
+=========================
 
 FADE: Transition pixels\*
-----------------------------
+-------------------------
 
-This controls the number of transition pixels around each postage stamp where it "fades away" while the next postage stamp "fades in". This ensures a smooth transition from one postage stamp to the next, even though they are constructed from different sets of input pixels. So for example, to set the number of transition pixels around each postage stamp to 2::
+This controls the number of transition pixels around each postage stamp where it "fades away" while the next postage stamp "fades in". This ensures a smooth transition from one postage stamp to the next, even though they are constructed from different sets of input pixels. So for example, to set the number of transition pixels around each postage stamp to 2:
+
+.. code-block:: json
 
        "FADE": 2
 
@@ -305,22 +358,26 @@ Specifying this is optional; it defaults to 3.
 A truncated sine function is used for the weights, so that the total weight is always 1.
 
 PAD: Padding postage stamps\*
--------------------------------
+-----------------------------
 
 *Optional; no padding if not set.*
 
-This tells PyIMCOM to compute an additional set of postage stamps around each block. So to compute 1 postage stamp around the edge::
+This tells PyIMCOM to compute an additional set of postage stamps around each block. So to compute 1 postage stamp around the edge:
+
+.. code-block:: json
 
       "PAD": 1
 
 For most applications where you may be interested in sources near the edge of a block, having a padding postage stamp is recommended. If there are n\_2 pixels per postage stamps, ``FADE`` =k, and ``PAD`` =P, then there will be 2(kn\_2-P) output pixels that are exactly the same between one block and the next. 
 
 PADSIDES: Which padding stamps to compute\*
-----------------------------------------------
+-------------------------------------------
 
 *Optional; defaults to "auto".*
 
-This tells PyIMCOM which padding stamps to compute. If you want to compute a stand-alone block without doing any additional post-processing (this is probably most applications), you should use ``"all"``::
+This tells PyIMCOM which padding stamps to compute. If you want to compute a stand-alone block without doing any additional post-processing (this is probably most applications), you should use ``"all"``:
+
+.. code-block:: json
 
    "PADSIDES": "all"
 
@@ -334,25 +391,29 @@ Other options include:
 - ``[BTLR]+`` : You may specify bottom, top, left, or right with a string containing one or more of these characters (e.g., ``"BRL"`` to compute bottom, right, and left padding stamps, but not the top).
 
 STOP: Compute only a portion of the block\*
-----------------------------------------------
+-------------------------------------------
 
 *Optional*
 
-If specified and positive, halts coaddition after the specified number of postage stamps have been coadded (``STOP=0`` is ignored). So the following will compute only the first 148 postage stamps and then stop::
+If specified and positive, halts coaddition after the specified number of postage stamps have been coadded (``STOP=0`` is ignored). So the following will compute only the first 148 postage stamps and then stop:
+
+.. code-block:: json
 
     "STOP": 148
 
 This will give you an output block that has the bottom filled in, but then the rest will be empty. This is mostly useful during de-bugging: you might want to run only, say, 1/4 of a block so that your modification -> re-run -> analysis -> next modification cycle is shorter.
 
 What and where to output
-===========================
+========================
 
 OUTMAPS: Which maps to save\*
--------------------------------
+-----------------------------
 
 *Optional; default is to save everything.*
 
-This is a string with a capital letter for each possible output we want to save, e.g. to save U, S, T, and N maps::
+This is a string with a capital letter for each possible output we want to save, e.g. to save U, S, T, and N maps:
+
+.. code-block:: json
 
    "OUTMAPS": "USTN"
 
@@ -376,33 +437,41 @@ Specific conventions for U, S, K, and T are as described in `Rowe et al. (2011) 
    x = 10**(HDU_to_bels(hdu)*hdu.data)
 
 OUT: Output file location
----------------------------
+-------------------------
 
-This is a stem for the output coadded image file locations. An example would be::
+This is a stem for the output coadded image file locations. An example would be:
+
+.. code-block:: json
 
     "OUT": "/fs/scratch/PCON0003/cond0007/itertest2-out/itertest2_F"
 
 which generates output file ``/fs/scratch/PCON0003/cond0007/itertest2-out/itertest2_F_02_00.fits`` for block (2,0).
 
 TEMPFILE: Temporary storage for a block\*
-----------------------------------------------
+-----------------------------------------
 
 *Optional; does not use virtual memory if not given.*
 
-This is a stem for temporary files during coaddition (e.g., virtual memory). This can be specified in the configuration file::
+This is a stem for temporary files during coaddition (e.g., virtual memory). This can be specified in the configuration file:
+
+.. code-block:: json
 
    "TEMPFILE": "/tmp/my_pyimcom_run"
 
-On some platforms, including the Ohio Supercomputer Center, a process only finds out the path for local storage on its node at runtime, so you can't use the hard-coded ``TEMPFILE`` in the configuration. In that case, the script that calls PyIMCOM should, after loading a configuration, find out which directory it is supposed to use. On OSC, this is provided by the ``$TMPDIR`` environment variable, so after loading the configuration in Python you would modify it::
+On some platforms, including the Ohio Supercomputer Center, a process only finds out the path for local storage on its node at runtime, so you can't use the hard-coded ``TEMPFILE`` in the configuration. In that case, the script that calls PyIMCOM should, after loading a configuration, find out which directory it is supposed to use. On OSC, this is provided by the ``$TMPDIR`` environment variable, so after loading the configuration in Python you would modify it:
+
+.. code-block:: python
 
    config_file = sys.argv[1]
    cfg = Config(config_file)
    cfg.tempfile = os.getenv('TMPDIR') + '/temp'
 
 INLAYERCACHE: Temporary storage for a mosaic
---------------------------------------------------
+--------------------------------------------
 
-This is also a stem for file storage::
+This is also a stem for file storage:
+
+.. code-block:: json
 
    "INLAYERCACHE": "/fs/scratch/PCON0003/cond0007/itertest2-out/cache/in_F"
 
@@ -411,23 +480,27 @@ The difference is that this is common to the *whole mosaic*, and in particular i
 **Comment**: The ``INLAYERCACHE`` stem is also being used to store data for some experimental features, so we expect to make more use of it in the future. Therefore even though PyIMCOM will run without it right now, we expect that most users will need it in the future and we recommend treating it as required.
 
 Target output PSFs
-=====================
+==================
 
 NOUT: Number of output PSFs\*
-------------------------------------------------
+-----------------------------
 
 *Deprecated*
 
-The number of output PSFs to generate simultaneously. The default is 1. So nothing will change if you write::
+The number of output PSFs to generate simultaneously. The default is 1. So nothing will change if you write:
+
+.. code-block:: json
 
     "NOUT": 1
 
 **Comment**: When this option was first introduced, the linear algebra engine in PyIMCOM required an eigendecomposition of the **A** matrix (see `Rowe et al. 2011 <https://ui.adsabs.harvard.edu/abs/2011ApJ...741...46R/abstract>`_). This was extremely slow, but once it was done it was relatively fast to generate multiple output PSFs at the same time. In the Cholesky decomposition approach, the advantage of doing multiple PSFs at once is much smaller, and the memory burden of handling all the outputs simultaneously has been found to slow things down. It is also not compatible (for math reasons, not coding reasons) with the PSF splitting that we plan to implement for Roman.
 
 OUTPSF: Output PSF type
-----------------------------
+-----------------------
 
-This sets the type of target output PSF::
+This sets the type of target output PSF:
+
+.. code-block:: json
 
    "OUTPSF": "GAUSSIAN"
 
@@ -442,23 +515,27 @@ The options are:
 In the latter two cases, the ``EXTRASMOOTH`` keyword determines the extra smoothing.
 
 EXTRASMOOTH: Output PSF Gaussian component
------------------------------------------------
+------------------------------------------
 
-This sets the Gaussian width (if ``OUTPSF`` is ``GAUSSIAN``) or the extra smoothing (if ``OUTPSF`` is one of the diffractive options). The width is the 1 sigma width (or rms per axis) in units of undistorted input pixels (i.e., 0.11 arcsec). So for example::
+This sets the Gaussian width (if ``OUTPSF`` is ``GAUSSIAN``) or the extra smoothing (if ``OUTPSF`` is one of the diffractive options). The width is the 1 sigma width (or rms per axis) in units of undistorted input pixels (i.e., 0.11 arcsec). So for example:
+
+.. code-block:: json
 
    "EXTRASMOOTH": 0.9767200703312219
 
 will give a Gaussian with a 1 sigma width of 0.97672x0.11 = 0.10744 arcsec.
 
 Building linear systems
-==========================
+=======================
 
 NPIXPSF: Size of PSF inner product arrays\*
-----------------------------------------------
+-------------------------------------------
 
 *Optional; default is 48.*
 
-This is the size of the arrays used to compute PSF inner products in native pixels (should be an even integer). So to set this to 42 native pixels or 42x0.11 = 4.64 arcsec, you may write::
+This is the size of the arrays used to compute PSF inner products in native pixels (should be an even integer). So to set this to 42 native pixels or 42x0.11 = 4.64 arcsec, you may write:
+
+.. code-block:: json
 
     "NPIXPSF": 42
 
@@ -469,44 +546,48 @@ The default of 48 is recommended for most Roman uses without PSF splitting for n
 Since the short-range PSF actually goes to zero, the arrays are sized differently (the convolved PSF arrays in ``pyimcom.psfutil.PSFOvl`` have approximately twice the size of the PSF images in ``pyimcom.psfutil.PSFGrp``). In this case, we know rigorously that ``NPIXPSF`` \>2(1+alpha)R\_{out}, where R\_{out} is the outer radius of the PSF and alpha is the geometric distortion (i.e., true pixel size is 0.11(1+alpha) arcsec), is sufficient. So this will be the plan for production runs on Roman data.
 
 PSFCIRC: Apply a circular cutout to the PSF\*
------------------------------------------------
+---------------------------------------------
 
 *Experimental feature; default=False*
 
 
 PSFNORM: Rescale thet normalization of the PSF\*
---------------------------------------------------
+------------------------------------------------
 
 *Experimental feature; default=False*
 
 AMPPEN: Apply an additional penalty in the PSF leakage for low-frequency modes in the PSF that do not match the target\*
----------------------------------------------------------------------------------------------------------------------------------------------
+------------------------------------------------------------------------------------------------------------------------
 
 *Deprecated, default = [0,0]*
 
 This was used in the first Roman IMCOM run `Hirata et al. (2024) <https://ui.adsabs.harvard.edu/abs/2024MNRAS.528.2533H/abstract>`_. We have since assessed that it is not needed.
 
 FLATPEN: Apply an additional penalty in the PSF leakage if the input images do not receive equal weight\*
-------------------------------------------------------------------------------------------------------------------------
+--------------------------------------------------------------------------------------------------------------
 
 *Deprecated; default = 0*
 
 This was used in the first Roman IMCOM run `Hirata et al. (2024) <https://ui.adsabs.harvard.edu/abs/2024MNRAS.528.2533H/abstract>`_. We have since assessed that it is not needed.
 
 INPAD: Selection of input pixels
---------------------------------------
+--------------------------------
 
-This sets the acceptance radius (in arcsec) around the postage stamp to select input pixels. See Fig. 4c of `Hirata et al. (2024) <https://ui.adsabs.harvard.edu/abs/2024MNRAS.528.2533H/abstract>`_. It is a single keyword/value::
+This sets the acceptance radius (in arcsec) around the postage stamp to select input pixels. See Fig. 4c of `Hirata et al. (2024) <https://ui.adsabs.harvard.edu/abs/2024MNRAS.528.2533H/abstract>`_. It is a single keyword/value:
+
+.. code-block:: json
 
     "INPAD": 1.05
 
 Solving linear systems
-===========================
+======================
 
 LAKERNEL: Setting the linear algebra kernel
------------------------------------------------------------------
+-------------------------------------------
 
-This sets the linear algebra kernel used to solve for the coaddition weights **T** in terms of the system matrices **A** and **B**::
+This sets the linear algebra kernel used to solve for the coaddition weights **T** in terms of the system matrices **A** and **B**:
+
+.. code-block:: json
 
     "LAKERNEL": "Cholesky"
 
@@ -520,31 +601,38 @@ The choices are (see `Cao et al. (2025) <https://ui.adsabs.harvard.edu/abs/2024a
 
 - ``Empirical`` : This is a fast approximation that does not actually solve the linear system. It does not reach PyIMCOM's potential for accuracy, but since it is fast it can be useful for testing whether your interfaces to PyIMCOM are working.
 
-The ``Iterative`` kernel uses two additional keywords (these are the default values)::
+The ``Iterative`` kernel uses two additional keywords (these are the default values):
+
+.. code-block:: json
 
    "ITERTOL": 1.5e-3
    "ITERMAX": 30
 
-The ``Empirical`` kernel takes an additional keyword that allows one to turn off the U_alpha/C and Sigma_alpha computations (default is false, but turning this on makes the code very fast)::
+The ``Empirical`` kernel takes an additional keyword that allows one to turn off the U_alpha/C and Sigma_alpha computations (default is false, but turning this on makes the code very fast):
+
+.. code-block:: json
 
    "EMPIRNQC": false
 
 KAPPAC: Lagrange multiplier array
------------------------------------------------------------------
+---------------------------------
 
-This sets the grid of Lagrange multipliers for Cholesky and Iterative methods. It is a list in ascending order::
+This sets the grid of Lagrange multipliers for Cholesky and Iterative methods. It is a list in ascending order:
+
+.. code-block:: json
 
        "KAPPAC": [0.0002]
 
 If one value is given (as in the above case), a single choice of kappa_alpha is used. If multiple values are given, then interpolation is used to approximate the Pareto front (see `Cao et al. 2025 <https://ui.adsabs.harvard.edu/abs/2024arXiv241005442C/abstract>`_ §3.1).
 
 UCMIN and SMAX: Bounding the search space of the Lagrange multiplier
------------------------------------------------------------------------
+--------------------------------------------------------------------
 
-These values describe the bounds in leakage U_alpha/C and noise Sigma_alpha metrics::
+These values describe the bounds in leakage U_alpha/C and noise Sigma_alpha metrics:
+
+.. code-block:: json
 
     "UCMIN": 1e-06,
     "SMAX": 0.5
 
 The "normal" behavior of PyIMCOM (except in Empirical mode, or if only a single value is given in ``KAPPAC``) is to find the best possible leakage performance subject to the noise constraint; but if the noise can be reduced below ``SMAX`` at U_alpha/C = ``UCMIN`` then it switches to this behavior.
-

--- a/docs/diagnostics_README.rst
+++ b/docs/diagnostics_README.rst
@@ -1,4 +1,3 @@
-======================
 Diagnostics in PyIMCOM
 ======================
 
@@ -9,7 +8,9 @@ Process for Generating a Report
 
 **Initializing a new report**
 
-The fundamental object is the ``ValidationReport`` class in the ``diagnostics.report`` module. This is built from a PyIMCOM output file (any block file in a mosaic may be used), and a "stem" for the output files is also given. So for example, one may write::
+The fundamental object is the ``ValidationReport`` class in the ``diagnostics.report`` module. This is built from a PyIMCOM output file (any block file in a mosaic may be used), and a "stem" for the output files is also given. So for example, one may write:
+
+.. code-block:: python
 
   from pyimcom.report import ValidationReport
   rpt=ValidationReport(
@@ -31,16 +32,22 @@ The ``ValidationReport`` class has attributes containing, among other things, th
 
 **Generating sections**
 
-The ``ReportSection`` class in the ``diagnostics.report`` module generates a report. *This is a base class and is not going to be used much by itself, rather each section of the report will be implemented as a subclass.* A report section is initialized by calling it from the report::
+The ``ReportSection`` class in the ``diagnostics.report`` module generates a report. *This is a base class and is not going to be used much by itself, rather each section of the report will be implemented as a subclass.* A report section is initialized by calling it from the report:
+
+.. code-block:: python
 
   from pyimcom.report import ReportSection
   sec = ReportSection(rpt)
 
-The report section has an ``infile`` function that can provide the name of a file with a given (*x*, *y*) block coordinate::
+The report section has an ``infile`` function that can provide the name of a file with a given (*x*, *y*) block coordinate:
+
+.. code-block:: python
 
   my_file = sec.infile(4,6) # returns location of block (4,6)
 
-You almost certainly will never need to override this. It has a ``build`` method that is intended to be overridden in a subclass. The ``build`` method can be of the form::
+You almost certainly will never need to override this. It has a ``build`` method that is intended to be overridden in a subclass. The ``build`` method can be of the form:
+
+.. code-block:: python
 
   sec.build(nblockmax=8) # nblockmax is for testing only
 
@@ -54,7 +61,9 @@ There are three attributes that need to be generated in the ``build`` method (th
 
 * ``result``: A one-line summary (e.g., "PASS" or "FAIL") from that report section, if applicable. (*Default*: "N/A")
 
-You can add your section to the report::
+You can add your section to the report:
+
+.. code-block:: python
 
   rpt.addsections([sec]) # adds one section
   rpt.addsections([sec1,sec2]) # adds two sections, sec1 and sec2
@@ -67,7 +76,9 @@ Comments:
 
 **Compiling the report:**
 
-You can compile the report via::
+You can compile the report via:
+
+.. code-block:: python
 
   rpt.compile(ntimes=3)
 
@@ -89,6 +100,8 @@ Currently Available Reports
     - *(base class)*
   * - ``MosaicImage``
     - Thumbnail of the mosaic
+  * - ``LayerReport``
+    - Percentile distribution of all of the layers
   * - ``SimulatedStar``
     - 1-point statistics of simulated stars
   * - ``NoiseReport``

--- a/docs/meta_README.rst
+++ b/docs/meta_README.rst
@@ -1,6 +1,5 @@
-********************
 PyIMCOM + Meta Tools
-********************
+####################
 
 First attempt at meta-ing images in PyIMCOM
 ===========================================
@@ -26,7 +25,9 @@ file using the ``shearimage_to_fits`` function.
 Stand-alone usage
 -----------------
 
-It is possible to call this module in a few different ways. A simple one is the following code, which rotates the image by 30 degrees and grows the PSF by a factor of 1.05::
+It is possible to call this module in a few different ways. A simple one is the following code, which rotates the image by 30 degrees and grows the PSF by a factor of 1.05:
+
+.. code-block:: python
 
   import numpy as np
   from pyimcom.meta import distortimage
@@ -38,17 +39,19 @@ It is possible to call this module in a few different ways. A simple one is the 
 This will work either with the original ``.fits`` files, or with the ``.cpr.fits.gz`` files.
 
 Detailed usage information
-****************************
+**************************
 
 There are several options available and points to keep in mind when working with the ``distortimage.MetaMosaic`` class.
 
 Building a MetaMosaic
-========================
+=====================
 
 Constructor
----------------
+-----------
 
-Construction of a mosaic is in principle quite simple: it is built from a PyIMCOM output file, with the optional ``verbose`` keyword::
+Construction of a mosaic is in principle quite simple: it is built from a PyIMCOM output file, with the optional ``verbose`` keyword:
+
+.. code-block:: python
 
    mosaic = distortimage.MetaMosaic('mymosaic_24_13.fits', verbose=True)
 
@@ -59,7 +62,7 @@ The constructor can work with either the raw ``.fits`` files, or with the compre
 The configuration that generated an object is accessible as an attribute, e.g., you may get the pixel scale in the coated image by asking for ``mosaic.cfg.dtheta``, or the additional layers from ``mosaic.cfg.extrainput``.
 
 Attributes
----------------
+----------
 
 The ``MetaMosaic`` class has the following attributes:
 
@@ -81,16 +84,22 @@ The ``MetaMosaic`` class has the following attributes:
 Masking an image
 ------------------
 
-The most general way to update the mask is with the ``maskpix`` method. For example, to mask pixels that are over 1.0e4 in the science image::
+The most general way to update the mask is with the ``maskpix`` method. For example, to mask pixels that are over 1.0e4 in the science image:
+
+.. code-block:: python
 
     mosaic.maskpix(mosaic.in_image[0,:,:]>1.0e4)
 
-There are also stand-alone masking functions for the fidelity and noise images. For example, you can mask pixels where the PyIMCOM fidelity is worse than 40 dB (i.e., U/C>1e-4) or the noise suppression is less than 3 dB (i.e., output noise variance is more than 10^(-0.3) of an input pixel)::
+There are also stand-alone masking functions for the fidelity and noise images. For example, you can mask pixels where the PyIMCOM fidelity is worse than 40 dB (i.e., U/C>1e-4) or the noise suppression is less than 3 dB (i.e., output noise variance is more than 10^(-0.3) of an input pixel):
+
+.. code-block:: python
 
     mosaic.mask_fidelity_cut(40.)
     mosaic.mask_noise_cut(3.)
 
-Finally, you could mask a bunch of circular regions (e.g., around a star catalog) using the ``mask_caps`` method::
+Finally, you could mask a bunch of circular regions (e.g., around a star catalog) using the ``mask_caps`` method:
+
+.. code-block:: python
 
     ra_mask = np.array([9.60, 9.70, 9.80]) # all coordinates in degrees
     dec_mask = np.array([-44.10, -44.20, -44.30])
@@ -99,9 +108,11 @@ Finally, you could mask a bunch of circular regions (e.g., around a star catalog
     mosaic.mask_caps(ra_mask, dec_mask, radius_mask) # this masks a different radius for each object
 
 Shearing an image
-==================
+=================
 
-A sheared image dictionary is generated from the ``shearimage`` method, e.g.::
+A sheared image dictionary is generated from the ``shearimage`` method, e.g.:
+
+.. code-block:: python
 
   im = mosaic.shearimage(3200,
     jac=[[np.cos(rot),np.sin(rot)],[-np.sin(rot),np.cos(rot)]],
@@ -171,7 +182,9 @@ The output dictionary has the following keys:
 - ``psf_fwhm``: The full width at half maximum of the PSF, in arcsec.
 - ``ref``: The projection center location (x,y) (tuple, 0-offset convention).
 
-You can return an equivalent dictionary without any shearing/reconvolution using ``origimage``::
+You can return an equivalent dictionary without any shearing/reconvolution using ``origimage``:
+
+.. code-block:: python
 
     im = mosaic.origimage(3200) # all layers
     im = mosaic.origimage(3200, select_layers=[0,2]) # select layers 0 (SCI) and 2.
@@ -179,9 +192,11 @@ You can return an equivalent dictionary without any shearing/reconvolution using
 (This will be **much** faster, since it is generating a subarray rather than a grid, but of course then any Meta-like shearing is the responsibility of a downstream module.)
 
 Writing to a file
-====================
+=================
 
-There is a simple function to write a sheared image dictionary to disk::
+There is a simple function to write a sheared image dictionary to disk:
+
+.. code-block:: python
 
   pyimcom.meta.shearimage_to_fits(im, fname, layers=None, overwrite=False)
 

--- a/docs/output_README.rst
+++ b/docs/output_README.rst
@@ -8,7 +8,9 @@ There are several options for reading PyIMCOM output files. From "lowest" to "hi
 
 * Compressed files have their non-science layers scrambled. They can be read using the
   ``pyimcom.compress.compressutils.ReadFile`` utility, which can be used just like
-  ``astropy.io.fits.open`` (including the context management)::
+  ``astropy.io.fits.open`` (including the context management):
+
+  .. code-block:: python
 
     from pyimcom.compress.compressutils import ReadFile
     # here fout is the file name that we want to read
@@ -17,19 +19,25 @@ There are several options for reading PyIMCOM output files. From "lowest" to "hi
        ...
 
   ``ReadFile`` also supports regular expression formatting for file names, with the block indices and suffix
-  separated from the format string by the ``^`` character. For example, you may use::
+  separated from the format string by the ``^`` character. For example, you may use:
+
+  .. code-block:: python
 
     # This reads the file "coadds/H158/Row14/prod_H_18_14_map.fits"
     ReadFile("coadds/H158/Row{1:02d}/prod_H_{0:02d}_{1:02d}^_18_14_map.fits")
 
-  It is even possible to read from the Internet via https::
+  It is even possible to read from the Internet via https:
+
+  .. code-block:: python
 
     ReadFile("https://irsa.ipac.caltech.edu/data/theory/openuniverse2024/roman/preview/RomanWAS/images/"
       "coadds/H158/Row14/prod_H_18_14_map.fits")
 
   The other tools listed below are built on top of ``ReadFile``.
 
-* The ``pyimcom.analysis.OutImage`` method builds one output block from the FITS file::
+* The ``pyimcom.analysis.OutImage`` method builds one output block from the FITS file:
+
+  .. code-block:: python
 
     from pyimcom.analysis import OutImage
     # here fout is the file name that we want to read
@@ -40,7 +48,9 @@ There are several options for reading PyIMCOM output files. From "lowest" to "hi
     fidelity_map = my_block.get_output_map('FIDELITY') # options are: 'FIDELITY', 'SIGMA', 'KAPPA', 'INTWTSUM', 'EFFCOVER'
 
 * The ``pyimcom.meta.distortimage.MetaMosaic`` class is the highest-level interface and constructs a sub-mosaic
-  from the 3x3 set of blocks centered on the specified file. It can be subarrayed, sheared, masked, etc.::
+  from the 3x3 set of blocks centered on the specified file. It can be subarrayed, sheared, masked, etc.:
+
+  .. code-block:: python
 
     from pyimcom.meta import distortimage
     # here fout is the file name that we want to read

--- a/docs/run_README.rst
+++ b/docs/run_README.rst
@@ -1,5 +1,5 @@
 Workflow to run PyIMCOM
-#############################
+#######################
 
 This is a quick guide for the jobs you will want to submit to build a mosaic in PyIMCOM. To build a mosaic, you will need:
 
@@ -12,7 +12,7 @@ This is a quick guide for the jobs you will want to submit to build a mosaic in 
 - Additional layer information (e.g., laboratory darks) if you are going to be requesting those as layers to coadd.
 
 Overall workflow
-******************
+****************
 
 There are several steps in the workflow:
 
@@ -29,7 +29,7 @@ There are several steps in the workflow:
 We describe each of these in turn below.
 
 Input data
-===================
+==========
 
 The input data may be in one of the following formats (more may be added in the future). Science images and lab darks are in subdirectories of the directory given by the ``INDATA`` keyword (first value); PSFs are in the directory given by the ``INPSF`` keyword (first value). The formats are: 
 
@@ -46,14 +46,16 @@ The input data may be in one of the following formats (more may be added in the 
 If your platform doesn't support putting all those files in one directory, we recommend symbolic links as a workaround.
 
 Generating input layers
-===========================
+=======================
 
 *Optional: only used if you have turned on INLAYERCACHE.*
 
 If ``INLAYERCACHE`` is set, then PyIMCOM will cache all of the input layers it generates itself (e.g., grids of injected objects, synthetic noise fields ...). The ``INLAYERCACHE`` keyword is a stem: if you set it to ``mydir/myprefix``, then all of the cached files will appear in ``mydir`` (or subdirectories) with a file name that starts with ``myprefix``.
 When a PyIMCOM process finds it needs one of these files, it first searches for it: if it is there then it simply reads from disk, otherwise it computes it and then saves to disk.
 
-You can use less computing time if you generate all the input layers first, and then do the coaddition. A simple way to do this if your configuration file is ``config_file`` and you are coadding blocks ``j1`` through ``j2`` (of ``BLOCK**2`` : recall this is the number of blocks in a square mosaic) is a script like ``gen1.py``::
+You can use less computing time if you generate all the input layers first, and then do the coaddition. A simple way to do this if your configuration file is ``config_file`` and you are coadding blocks ``j1`` through ``j2`` (of ``BLOCK**2`` : recall this is the number of blocks in a square mosaic) is a script like ``gen1.py``:
+
+.. code-block:: python
 
    import sys
    from pyimcom.config import Config
@@ -63,7 +65,9 @@ You can use less computing time if you generate all the input layers first, and 
    cfg.stoptile=4
    block = Block(cfg=cfg, this_sub=int(sys.argv[2]))
 
-(the ``stoptile`` tells PyIMCOM not to run through the coalition of the whole block) and then you can write a Perl script like::
+(the ``stoptile`` tells PyIMCOM not to run through the coalition of the whole block) and then you can write a Perl script like:
+
+.. code-block:: perl
 
    for $j ($j1..$j2) {
        system "python3 gen1.py config $j > log-gen.$j";
@@ -74,7 +78,9 @@ You could generate all of the input layers in series with ``$j1=0`` and ``$j2=BL
 Running the coaddition
 ==============================
 
-This is the most time-consuming step. In principle, all the blocks can be run in parallel. So you could run a script like ``run_coaddition.py``::
+This is the most time-consuming step. In principle, all the blocks can be run in parallel. So you could run a script like ``run_coaddition.py``:
+
+.. code-block:: python
 
    import sys
    from pyimcom.config import Config
@@ -85,7 +91,9 @@ This is the most time-consuming step. In principle, all the blocks can be run in
    block = Block(cfg=cfg, this_sub=int(sys.argv[2]))
    if int(sys.argv[2])==0: gen_truthcats_from_cfg(cfg)
 
-and then call::
+and then call:
+
+.. code-block:: bash
 
    python3 run_coaddition.py config $j > log-coadd.$j
 
@@ -94,9 +102,11 @@ You could put this in a loop in a Perl script, but on the Ohio Supercomputer Cen
 The "truth catalog" for the layers that PyIMCOM draws only needs to be generated once in a given mosaic. The above script generates it with the first block.
 
 Generating the diagnostic report
-=====================================
+================================
 
-You can generate a diagnostic report by running the diagnostics module *after* the coaddition has finished::
+You can generate a diagnostic report by running the diagnostics module *after* the coaddition has finished:
+
+.. code-block:: bash
 
    python3 -m pyimcom.diagnostics.run outdir/outstem_00_00.fits writeupdir/writeupstem
 

--- a/docs/splitpsf_README.rst
+++ b/docs/splitpsf_README.rst
@@ -56,7 +56,9 @@ Details
 Setup
 =====
 
-If PSF splitting is used, then *before* the main PyIMCOM run, one must run PSF splitting, e.g.::
+If PSF splitting is used, then *before* the main PyIMCOM run, one must run PSF splitting, e.g.:
+
+.. code-block:: bash
 
   python3 -m pyimcom.splitpsf.splitpsf config.json
 
@@ -65,11 +67,15 @@ If PSF splitting is used, then *before* the main PyIMCOM run, one must run PSF s
 Configuration options for PSF splitting
 ---------------------------------------
 
-The configuration file can contain an entry that activates PSF splitting, e.g.::
+The configuration file can contain an entry that activates PSF splitting, e.g.:
 
-  "PSFSPLIT": [6, 10, 0.01]
+.. code-block:: json
+
+  "PSFSPLIT": [6, 10, 0.01, true]
 
 Here the first 2 entries are the range of pixels (in this case: the "short range" PSF cuts of 6-10 native pixels from the center); and the last entry (here: 0.01) is the regularization parameter (epsilon) that prevents division by zero in constructing K_i. Smaller values will produce a more accurate PSF (smaller zeta_i) but be noisier (contain more positive and negative lobes).
+
+The field (``true``) is optional; if set to true, then the wing subtraction is run at half the resolution (in the case above: 3 subpixels per native pixel). This is faster (especially with lots of layers), and recommended if it meets your accuracy needs.
 
 PSF split format file
 ---------------------

--- a/docs/splitpsf_README.rst
+++ b/docs/splitpsf_README.rst
@@ -77,6 +77,14 @@ Here the first 2 entries are the range of pixels (in this case: the "short range
 
 The field (``true``) is optional; if set to true, then the wing subtraction is run at half the resolution (in the case above: 3 subpixels per native pixel). This is faster (especially with lots of layers), and recommended if it meets your accuracy needs.
 
+By default, the kernel subtraction step uses the same polynomial order for spatial variation as is in the input PSF files. This can be changed (for speed-up) by providing an order in the cofiguration, e.g.
+
+.. code-block:: json
+
+  "PORDER_IMSUBTRACT": 1
+
+will use polynomial order 1 (in both x and y) even if the input files have data through higher order.
+
 PSF split format file
 ---------------------
 

--- a/src/pyimcom/__init__.py
+++ b/src/pyimcom/__init__.py
@@ -1,1 +1,9 @@
+import warnings
+
+from asdf.exceptions import AsdfConversionWarning, AsdfPackageVersionWarning
+
 from ._version import __version__  # noqa: F401
+
+# disable some asdf warnings
+warnings.filterwarnings("ignore", category=AsdfConversionWarning)
+warnings.filterwarnings("ignore", category=AsdfPackageVersionWarning)

--- a/src/pyimcom/config.py
+++ b/src/pyimcom/config.py
@@ -672,7 +672,9 @@ class Config:
 
         print("# PSF splitting order for imsubtract", flush=True)
         self._get_attrs_wrapper(
-            "self.porder_imsubtract = int(input('PORDER_IMSUBTRACT (int) [default: -1]: '))"
+            "PORDER_IMSUBTRACT= input('PORDER_IMSUBTRACT (int) [default: -1]: ')"
+            "\n"
+            "self.porder_imsubtract = int(PORDER_IMSUBTRACT) if PORDER_IMSUBTRACT else -1"
         )
 
         print("### SECTION II: MASKS AND LAYERS ###\n", flush=True)

--- a/src/pyimcom/config.py
+++ b/src/pyimcom/config.py
@@ -669,9 +669,11 @@ class Config:
             " self.psfsplit_bin2x2] if"
             " self.psfsplit_r1 else ''"
         )
-        
+
         print("# PSF splitting order for imsubtract", flush=True)
-        self._get_attrs_wrapper("self.porder_imsubtract = int(input('PORDER_IMSUBTRACT (int) [default: -1]: '))")
+        self._get_attrs_wrapper(
+            "self.porder_imsubtract = int(input('PORDER_IMSUBTRACT (int) [default: -1]: '))"
+        )
 
         print("### SECTION II: MASKS AND LAYERS ###\n", flush=True)
         # masks and layers: PMASK, CMASK, EXTRAINPUT, LABNOISETHRESHOLD

--- a/src/pyimcom/config.py
+++ b/src/pyimcom/config.py
@@ -312,6 +312,7 @@ class Config:
         "psfsplit_epsilon",
         "psfsplit_bin2x2",  # SECTION I
         "permanent_mask",
+        "porder_imsubtract",
         "cr_mask_rate",
         "extrainput",
         "n_inframe",
@@ -469,6 +470,7 @@ class Config:
         self.inpsf_path, self.inpsf_format, self.inpsf_oversamp = cfg_dict["INPSF"]
         # if PSF splitting is used
         self.psfsplit = cfg_dict.get("PSFSPLIT", "")
+        self.porder_imsubtract = cfg_dict.get("PORDER_IMSUBTRACT", -1)
 
         ### SECTION II: MASKS AND LAYERS ###
         # permanent mask file
@@ -667,6 +669,9 @@ class Config:
             " self.psfsplit_bin2x2] if"
             " self.psfsplit_r1 else ''"
         )
+        
+        print("# PSF splitting order for imsubtract", flush=True)
+        self._get_attrs_wrapper("self.porder_imsubtract = int(input('PORDER_IMSUBTRACT (int) [default: -1]: '))")
 
         print("### SECTION II: MASKS AND LAYERS ###\n", flush=True)
         # masks and layers: PMASK, CMASK, EXTRAINPUT, LABNOISETHRESHOLD
@@ -1115,6 +1120,7 @@ class Config:
                 self.psfsplit_epsilon,
                 self.psfsplit_bin2x2,
             ]
+        cfg_dict["PORDER_IMSUBTRACT"] = self.porder_imsubtract
 
         ### SECTION II: MASKS AND LAYERS ###
         cfg_dict["PMASK"] = self.permanent_mask

--- a/src/pyimcom/config.py
+++ b/src/pyimcom/config.py
@@ -309,7 +309,8 @@ class Config:
         "psfsplit",
         "psfsplit_r1",
         "psfsplit_r2",
-        "psfsplit_epsilon",  # SECTION I
+        "psfsplit_epsilon",
+        "psfsplit_bin2x2",  # SECTION I
         "permanent_mask",
         "cr_mask_rate",
         "extrainput",
@@ -412,6 +413,7 @@ class Config:
             self.psfsplit_r1 = float(self.psfsplit[0])
             self.psfsplit_r2 = float(self.psfsplit[1])
             self.psfsplit_epsilon = float(self.psfsplit[2])
+            self.psfsplit_bin2x2 = len(self.psfsplit) > 3 and bool(self.psfsplit[3])
 
         ### SECTION II: MASKS AND LAYERS ###
         self.n_inframe = len(self.extrainput)
@@ -657,11 +659,13 @@ class Config:
 
         print("# PSF splitting", flush=True)
         self._get_attrs_wrapper(
-            "self.psfsplit_r1, self.psfsplit_r2, self.psfsplit_epsilon = input('PSFSPLIT (float float float) "
+            "self.psfsplit_r1, self.psfsplit_r2, self.psfsplit_epsilon, self.psfsplit_bin2x2 = "
+            "input('PSFSPLIT (float float float bool) "
             "[default: no split]: ').split(' ')"
             "\n"
-            "self.psfsplit = [self.psfsplit_r1, self.psfsplit_r2, self.psfsplit_epsilon] if self.psfsplit_r1 "
-            "else ''"
+            "self.psfsplit = [self.psfsplit_r1, self.psfsplit_r2, self.psfsplit_epsilon,"
+            " self.psfsplit_bin2x2] if"
+            " self.psfsplit_r1 else ''"
         )
 
         print("### SECTION II: MASKS AND LAYERS ###\n", flush=True)
@@ -1105,7 +1109,12 @@ class Config:
         cfg_dict["FILTER"] = self.use_filter
         cfg_dict["INPSF"] = [self.inpsf_path, self.inpsf_format, self.inpsf_oversamp]
         if self.psfsplit:
-            cfg_dict["PSFSPLIT"] = [self.psfsplit_r1, self.psfsplit_r2, self.psfsplit_epsilon]
+            cfg_dict["PSFSPLIT"] = [
+                self.psfsplit_r1,
+                self.psfsplit_r2,
+                self.psfsplit_epsilon,
+                self.psfsplit_bin2x2,
+            ]
 
         ### SECTION II: MASKS AND LAYERS ###
         cfg_dict["PMASK"] = self.permanent_mask

--- a/src/pyimcom/imdestripe.py
+++ b/src/pyimcom/imdestripe.py
@@ -83,6 +83,7 @@ from concurrent.futures import ProcessPoolExecutor, as_completed
 
 import asdf
 import numpy as np
+from asdf.exceptions import AsdfConversionWarning, AsdfPackageVersionWarning
 from astropy import wcs
 from astropy.io import fits
 from filelock import FileLock, Timeout
@@ -98,25 +99,27 @@ try:
 except ImportError:
     warnings.warn("furry_parakeet not available, won't be able to run imdestripe.")
 
-from asdf.exceptions import AsdfConversionWarning, AsdfPackageVersionWarning
-
 testoutputs = {
     "testing": False,  # Is this run for testing only? (usually False)
     "test_image_dir": "./",  # Location for test outputs (gets overwritten)
 }
-
-# Suppress ASDF warnings
-warnings.filterwarnings("ignore", category=AsdfConversionWarning)
-warnings.filterwarnings("ignore", category=AsdfPackageVersionWarning)
 
 if JWST:
     Settings.jwst()
 filters = Settings.RomanFilters
 t0_global = time.time()  # after imports
 
+# disable some asdf warnings
+warnings.filterwarnings("ignore", category=AsdfConversionWarning)
+warnings.filterwarnings("ignore", category=AsdfPackageVersionWarning)
+
 # Module settings
 use_output_float = np.float32
-tempdir = str(os.environ["TMPDIR"]) + "/" if "TMPDIR" in os.environ else "./"
+tempdir = (
+    str(os.environ["IMDESTRIPE_TMPDIR"])
+    if "IMDESTRIPE_TMPDIR" in os.environ
+    else (str(os.environ["TMPDIR"]) + "/" if "TMPDIR" in os.environ else "./")
+)
 
 # For test outputs: set sca=0 to not produce test outputs.
 img_full_output = {"obsid": 670, "scaid": 10}
@@ -1813,7 +1816,7 @@ def linear_search_general(
             )  # secant update
             write_to_file(f"Secant update: alpha_test={alpha_test}", of)
             method = "secant"
-            if np.isnan(alpha_test):
+            if not np.isfinite(alpha_test):
                 write_to_file("Secant update fail-- bisecting instead", of)
                 alpha_test = 0.5 * (alpha_min + alpha_max)  # bisection update
                 write_to_file(f"Bisection update: alpha_test={alpha_test}", of)

--- a/src/pyimcom/splitpsf/imsubtract.py
+++ b/src/pyimcom/splitpsf/imsubtract.py
@@ -31,7 +31,7 @@ from furry_parakeet import (
     pyimcom_croutines,
 )
 from scipy.fft import irfft2, next_fast_len, rfft2
-from scipy.signal import fftconvolve
+from scipy.signal import convolve, fftconvolve
 from scipy.signal.windows import tukey
 from scipy.special import eval_legendre
 
@@ -238,6 +238,30 @@ def get_wcs_from_infile(infile):
     return block_wcs
 
 
+def reinterp(arr):
+    """
+    Interpolates and rescales an array.
+
+    The array `arr[1:-1, 1:-1]` is interpolated onto a new grid at double the spacing.
+    (This is equivalent to 2x2 binning, except that we don't grow the pixel tophat.)
+
+    Parameters
+    ----------
+    arr : np.ndarray
+        The input array; must be 2D, even size, shape (2*N+2, 2*N+2).
+
+    Returns
+    -------
+    np.ndarray
+        The output array, shape (N, N).
+
+    """
+
+    _f = np.array([-0.125, 1.125, 1.125, -0.125]).astype(np.float32)
+    f2d = np.outer(_f, _f)
+    return convolve(arr, f2d, mode="valid", method="direct")[::2, ::2]
+
+
 def run_imsubtract_single(
     cfgdata,
     scaid,
@@ -349,8 +373,15 @@ def run_imsubtract_single(
             if oversamp % 2 and not axis_num // oversamp % 2:
                 # need to trim 1 native pixel so axis_num / oversamp is odd
                 axis_num -= oversamp
-                K = K[:, oversamp:-oversamp, oversamp:-oversamp]
-            K = np.sum(K.reshape((Ncoeff, axis_num, 2, axis_num, 2)), axis=(-3, -1))
+                K = K[:, oversamp - 1 : 1 - oversamp, oversamp - 1 : 1 - oversamp]
+            else:
+                K = np.pad(K, ((0, 0), (1, 1), (1, 1)), mode="edge")
+            for j in range(Ncoeff):
+                Kslice = reinterp(K[j, :, :])
+                if j == 0:
+                    _K = np.zeros((Ncoeff,) + np.shape(Kslice), dtype=np.float32)
+                _K[j, :, :] = Kslice
+            K = _K
 
     # SCA padding
     I_pad = int(np.ceil(axis_num / 2 / oversamp))  # native pixels

--- a/src/pyimcom/splitpsf/imsubtract.py
+++ b/src/pyimcom/splitpsf/imsubtract.py
@@ -768,7 +768,7 @@ def run_imsubtract(
     mmap : str or str-like, optional
         Directory to put temporary mmap files.
     bin2x2 : bool, optional
-        If True, bin the kernel 2x2 for speed.
+        If True, bin the kernel 2x2 for speed even if `config_file` doesn't tell you to.
 
     Notes
     -----
@@ -782,6 +782,7 @@ def run_imsubtract(
 
     # load the file using Config and get information
     cfgdata = Config(config_file)
+    bin2x2 = bin2x2 or getattr(cfgdata, "psfsplit_bin2x2", False)  # possible override of config
 
     # separate the path from the inlayercache info
     m = re.search(r"^(.*)\/(.*)", cfgdata.inlayercache)

--- a/src/pyimcom/splitpsf/imsubtract.py
+++ b/src/pyimcom/splitpsf/imsubtract.py
@@ -479,7 +479,10 @@ def run_imsubtract_single(
         print(f"Layer {n+1}", flush=True)
         H_canvas[:, :] = 0.0
         # define other important quantities for convolution
-        Nl = int(np.floor(np.sqrt(Ncoeff + 0.5)))
+        if cfgdata.porder_imsubtract >= 0:
+            Nl = cfgdata.porder_imsubtract 
+        else:
+            Nl = int(np.floor(np.sqrt(Ncoeff + 0.5)))
         KH[:, :] = 0.0
         x_canvas = np.linspace(-I_pad - 0.5 + 0.5 / oversamp, sca_nside + I_pad - 0.5 - 0.5 / oversamp, A)
         u_canvas = (x_canvas - (sca_nside - 1) / 2) / (sca_nside / 2)

--- a/src/pyimcom/splitpsf/imsubtract.py
+++ b/src/pyimcom/splitpsf/imsubtract.py
@@ -480,7 +480,7 @@ def run_imsubtract_single(
         H_canvas[:, :] = 0.0
         # define other important quantities for convolution
         if cfgdata.porder_imsubtract >= 0:
-            Nl = cfgdata.porder_imsubtract 
+            Nl = cfgdata.porder_imsubtract
         else:
             Nl = int(np.floor(np.sqrt(Ncoeff + 0.5)))
         KH[:, :] = 0.0

--- a/src/pyimcom/splitpsf/imsubtract.py
+++ b/src/pyimcom/splitpsf/imsubtract.py
@@ -493,10 +493,6 @@ def run_imsubtract_single(
             if (ix, iy) in skipblocks:
                 continue
 
-            if max_layers is not None and block_count > max_layers:  # Max blocks = 5 when testing
-                print(f"Reached max_blocks={max_layers}, stopping early for testing.")
-                break
-
             print("BLOCK: ", ix, iy)
             print(f"Block count: {block_count}/{max_layers if max_layers is not None else len(block_list)}")
             t0 = time.time()

--- a/src/pyimcom/splitpsf/imsubtract.py
+++ b/src/pyimcom/splitpsf/imsubtract.py
@@ -250,6 +250,7 @@ def run_imsubtract_single(
     wcs_shortcut=True,
     max_layers=None,
     mmap=None,
+    bin2x2=False,
 ):
     """
     Main routine to run imsubtract on a single image.
@@ -281,6 +282,8 @@ def run_imsubtract_single(
         Maximum number of layers to process. (For testing; default is None, which means no limit.)
     mmap : str or str-like, optional
         Directory to put temporary mmap files.
+    bin2x2 : bool, optional
+        If True, bin the kernel 2x2 for speed.
 
     Notes
     -----
@@ -335,6 +338,19 @@ def run_imsubtract_single(
 
         # get the oversampling factor
         oversamp = hdul2[0].header["OVSAMP"]  # number of kernel pixels / native pixels
+        if axis_num % (2 * oversamp):
+            raise ValueError(f"axis_num={axis_num} must be a multiple of 2*oversamp, oversamp={oversamp}")
+
+        if bin2x2:
+            if oversamp % 2:
+                raise ValueError(f"oversamp={oversamp:d} is odd, not consistent with bin2x2")
+            oversamp //= 2
+            axis_num //= 2
+            if oversamp % 2 and not axis_num // oversamp % 2:
+                # need to trim 1 native pixel so axis_num / oversamp is odd
+                axis_num -= oversamp
+                K = K[:, oversamp:-oversamp, oversamp:-oversamp]
+            K = np.sum(K.reshape((Ncoeff, axis_num, 2, axis_num, 2)), axis=(-3, -1))
 
     # SCA padding
     I_pad = int(np.ceil(axis_num / 2 / oversamp))  # native pixels
@@ -434,7 +450,7 @@ def run_imsubtract_single(
         # define other important quantities for convolution
         Nl = int(np.floor(np.sqrt(Ncoeff + 0.5)))
         KH[:, :] = 0.0
-        x_canvas = np.linspace(-I_pad - 0.5 + 0.5 / oversamp, sca_nside + I_pad - 0.5 + 0.5 / oversamp, A)
+        x_canvas = np.linspace(-I_pad - 0.5 + 0.5 / oversamp, sca_nside + I_pad - 0.5 - 0.5 / oversamp, A)
         u_canvas = (x_canvas - (sca_nside - 1) / 2) / (sca_nside / 2)
 
         # These will be overwritten if the block is not skipped
@@ -690,6 +706,7 @@ def run_imsubtract(
     wcs_shortcut=True,
     max_layers=None,
     mmap=None,
+    bin2x2=False,
 ):
     """
     Main routine to run imsubtract.
@@ -719,6 +736,8 @@ def run_imsubtract(
         Maximum number of layers to process. (For testing; default is None, which means no limit.)
     mmap : str or str-like, optional
         Directory to put temporary mmap files.
+    bin2x2 : bool, optional
+        If True, bin the kernel 2x2 for speed.
 
     Notes
     -----
@@ -773,6 +792,7 @@ def run_imsubtract(
             wcs_shortcut=wcs_shortcut,
             max_layers=max_layers,
             mmap=mmap,
+            bin2x2=bin2x2,
         )
 
         # exit if we've specified a maximum number of SCAs

--- a/src/pyimcom/splitpsf/imsubtract_wrapper.py
+++ b/src/pyimcom/splitpsf/imsubtract_wrapper.py
@@ -10,7 +10,14 @@ from .imsubtract import run_imsubtract_single
 
 
 def run_imsubtract_all(
-    cfg_file, workers=4, fft_workers=None, max_imgs=None, display=None, local_output=False, mmap=None
+    cfg_file,
+    workers=4,
+    fft_workers=None,
+    max_imgs=None,
+    display=None,
+    local_output=False,
+    mmap=None,
+    bin2x2=False,
 ):
     """
     Main routine to run imsubtract on all images in the cache.
@@ -32,6 +39,9 @@ def run_imsubtract_all(
         Whether to direct the file to local output instead of the cache directory.
     mmap : str or str-like, optional
         Directory to put temporary mmap files.
+    bin2x2 : bool, optional
+        If True, bin the kernel 2x2 for speed.
+
     """
 
     # Additional imports
@@ -88,6 +98,7 @@ def run_imsubtract_all(
                         local_output=local_output,
                         max_layers=max_imgs,
                         mmap=mmap,
+                        bin2x2=bin2x2,
                     )
                 )
                 count += 1

--- a/src/pyimcom/splitpsf/imsubtract_wrapper.py
+++ b/src/pyimcom/splitpsf/imsubtract_wrapper.py
@@ -40,7 +40,7 @@ def run_imsubtract_all(
     mmap : str or str-like, optional
         Directory to put temporary mmap files.
     bin2x2 : bool, optional
-        If True, bin the kernel 2x2 for speed.
+        If True, bin the kernel 2x2 for speed even if `config_file` doesn't tell you to.
 
     """
 

--- a/src/pyimcom/splitpsf/imsubtract_wrapper.py
+++ b/src/pyimcom/splitpsf/imsubtract_wrapper.py
@@ -70,6 +70,8 @@ def run_imsubtract_all(
 
     # print("List of exposures:", exps)
 
+    bin2x2 = bin2x2 or getattr(cfgdata, "psfsplit_bin2x2", False)  # possible override of config
+
     # Run imsubtract on each exposure in parallel using ProcessPoolExecutor
     count = 0
     start_method = "forkserver" if os.name.lower() == "posix" else "spawn"

--- a/src/pyimcom/splitpsf/splitpsf.py
+++ b/src/pyimcom/splitpsf/splitpsf.py
@@ -416,8 +416,22 @@ def split_psf_to_fits(psf_file, wcs_format, pars, outfile):
     print("K2int:", K2int)
 
 
-def main(cfgfile):
-    """Drives splitpsf from a configuration file."""
+def main(cfgfile, savezeta=False):
+    """
+    Drives splitpsf from a configuration file.
+
+    Parameters
+    ----------
+    cfgfile : str or str-like
+        The configuration file location.
+    savezeta : bool, optional
+        Additional output, only for testing.
+
+    Returns
+    -------
+    None
+
+    """
 
     # Extract the information we need from the config file
     with open(cfgfile) as f:
@@ -479,7 +493,7 @@ def main(cfgfile):
                     "r_in": r1,
                     "r_out": r2,
                     "eps": epsilon,
-                    "SAVEZETA": False,
+                    "SAVEZETA": savezeta,
                     "oversamp": ovsamp,
                 },
                 outfile,

--- a/src/pyimcom/splitpsf/splitpsf.py
+++ b/src/pyimcom/splitpsf/splitpsf.py
@@ -448,9 +448,9 @@ def main(cfgfile, savezeta=False):
     try:
         os.mkdir(targetdir)
         print("made directory -->", targetdir)
-    except OSError as error:
-        print("Couldn't make directory", targetdir, ":", error)
-        raise
+    except OSError as e:
+        print("Couldn't make directory", targetdir, ":", e)
+        raise e
 
     use_filter = Settings.RomanFilters[int(cfg_dict["FILTER"])]
 

--- a/src/pyimcom/splitpsf/splitpsf.py
+++ b/src/pyimcom/splitpsf/splitpsf.py
@@ -19,6 +19,33 @@ class SplitPSF:
     """
     Class for splitting the PSF into short- and long-range parts.
 
+    Parameters
+    ----------
+    psfcube : np.ndarray of float
+        A PSF data cube in Legendre polynomial format. Each slice is a PSF image,
+        that should be multiplied by P_m(u_) P_n(v_) where flatten((n,m)) = range((order+1)**2).
+        Here (u_, v_) are the coordinates on the SCA (scaled to the range -1 to +1).
+    wcs_ : pyimcom.wcsutil.PyIMCOM_WCS, optional
+        The WCS associated with the image. if None, then no distortion.
+    pars : dict
+        The dictionary of parameters. The choices (and defaults if not specified) are:
+
+        - ``ref_pixscale`` = 0.11 (arcsec) -> reference native pixel scale (without distortion)
+        - ``oversamp`` = 8 -> oversampling of PSF relative to native scale
+        - ``tophat_in`` = False -> pixel tophat already included
+        - ``smallstamp_size`` = [side length of psfcube] -> size of small PSF postage stamp, in units of the
+          oversampled pixels
+        - ``nside`` = 4088 -> SCA side length
+        - ``r_in`` = 4.0 -> inner cut radius in native pixels
+        - ``r_out`` = 9.0 -> inner cut radius in native pixels
+        - ``sigmaGamma`` = 1.0 -> 1 sigma scale length of the desired output PSF, in reference input pixels
+        - ``eps`` = 0.02 -> regularization parameter in Gaussian deconvolution of the PSF wings
+        - ``m_trunc`` = 0 -> truncation window width at edge of PSF postage stamp
+          (in units of oversampled pixels)
+
+        A constraint is that PSF input and output sizes are even numbers of oversampled pixels, with (0,0)
+        at the center of the array.
+
     Methods
     -------
     Window_integratedBlackman
@@ -158,68 +185,22 @@ class SplitPSF:
         )
 
     def __init__(self, psfcube, wcs_, pars):
-        """Class constructor to generate a split PSF from a Legendre cube file.
+        """Constructor."""
 
-        Inputs:
-           psfcube = a PSF data cube in Legendre polynomial format. Each slice is a PSF image,
-              that should be multiplied by P_m(u_) P_n(v_) where flatten((n,m)) = range((order+1)**2)
-              where (u_, v_) are the coordinates on the SCA
+        self.ref_pixscale = pars.get("ref_pixscale", 0.11)
+        self.oversamp = pars.get("oversamp", 8)
+        self.tophat_in = pars.get("tophat_in", False)
+        self.largestamp_size = np.shape(psfcube)[1]
+        self.smallstamp_size = pars.get("smallstamp_size", self.largestamp_size)
+        self.nside = pars.get("nside", 4088)
+        self.r_in = pars.get("r_in", 4.0)
+        self.r_out = pars.get("r_out", 9.0)
+        self.sigmaGamma = pars.get("sigmaGamma", 1.0)
+        self.eps = pars.get("eps", 0.02)
+        self.m_trunc = pars.get("m_trunc", 0)
 
-           wcs_ = WCS associated with the image. if None, then no distortion
-
-           pars = dictionary of parameters. The choices (and defaults if not specified) are:
-              ref_pixscale = 0.11 (arcsec) -> reference native pixel scale (without distortion)
-              oversamp = 8 -> oversampling of PSF relative to native scale
-              tophat_in = False -> pixel tophat already included
-              smallstamp_size = [side length of psfcube] -> size of small PSF postage stamp, in units of the
-                                                            oversampled pixels
-              nside = 4088 -> SCA side length
-              r_in = 4.0 -> inner cut radius in native pixels
-              r_out = 9.0 -> inner cut radius in native pixels
-              sigmaGamma = 1.0 -> 1 sigma scale length of the desired output PSF, in reference input pixels
-              eps = 0.02 -> regularization parameter in Gaussian deconvolution of the PSF wings
-              m_trunc = 0 -> truncation window width at edge of PSF postage stamp
-                             (in units of oversampled pixels)
-
-        A constraint is that PSF input and output sizes are even numbers of oversampled pixels, with (0,0)
-        at the center of the array.
-        """
-
-        self.ref_pixscale = 0.11
-        if "ref_pixscale" in pars:
-            self.ref_pixscale = pars["ref_pixscale"]
-        self.oversamp = 8
-        if "oversamp" in pars:
-            self.oversamp = pars["oversamp"]
-        self.tophat_in = False
-        if "tophat_in" in pars:
-            self.tophat_in = pars["tophat_in"]
-        self.smallstamp_size = self.largestamp_size = np.shape(psfcube)[1]
-        if "smallstamp_size" in pars:
-            self.smallstamp_size = pars["smallstamp_size"]
-        self.nside = 4088
-        if "nside" in pars:
-            self.nside = pars["nside"]
-        self.r_in = 4.0
-        if "r_in" in pars:
-            self.r_in = pars["r_in"]
-        self.r_out = 9.0
-        if "r_out" in pars:
-            self.r_out = pars["r_out"]
-        self.sigmaGamma = 1.0
-        if "sigmaGamma" in pars:
-            self.sigmaGamma = pars["sigmaGamma"]
-        self.eps = 0.02
-        if "eps" in pars:
-            self.eps = pars["eps"]
-        self.m_trunc = 0
-        if "m_trunc" in pars:
-            self.m_trunc = pars["m_trunc"]
-
-        if self.tophat_in:
-            self.psfcube = np.copy(psfcube)  # copy ensures the same reference behavior in both casees
-        else:
-            self.psfcube = SplitPSF.tophatfilter(psfcube, self.oversamp)
+        # PSF cube; copy ensures the same reference behavior in both cases
+        self.psfcube = np.copy(psfcube) if self.tophat_in else SplitPSF.tophatfilter(psfcube, self.oversamp)
 
         self.wcs_ = wcs_
 
@@ -469,6 +450,7 @@ def main(cfgfile, savezeta=False):
         print("made directory -->", targetdir)
     except OSError as error:
         print("Couldn't make directory", targetdir, ":", error)
+        raise
 
     use_filter = Settings.RomanFilters[int(cfg_dict["FILTER"])]
 

--- a/tests/pyimcom/test_cfg.py
+++ b/tests/pyimcom/test_cfg.py
@@ -47,7 +47,7 @@ def test_interface(tmp_path):
     # PSFSPLIT
     script += "5.5 9.5 0.01 False\n"
     # PORDER_IMSUBTRACT
-    script += "3\n"
+    script += "\n"
 
     # SECTION II
     # PMASK

--- a/tests/pyimcom/test_cfg.py
+++ b/tests/pyimcom/test_cfg.py
@@ -46,6 +46,8 @@ def test_interface(tmp_path):
     script += tdir + "/psf6 L2_2506 6\n"
     # PSFSPLIT
     script += "5.5 9.5 0.01 False\n"
+    # PORDER_IMSUBTRACT
+    script += "3\n"
 
     # SECTION II
     # PMASK

--- a/tests/pyimcom/test_cfg.py
+++ b/tests/pyimcom/test_cfg.py
@@ -45,7 +45,7 @@ def test_interface(tmp_path):
     # INPSF
     script += tdir + "/psf6 L2_2506 6\n"
     # PSFSPLIT
-    script += "5.5 9.5 0.01\n"
+    script += "5.5 9.5 0.01 False\n"
 
     # SECTION II
     # PMASK

--- a/tests/pyimcom/test_imdestripe.py
+++ b/tests/pyimcom/test_imdestripe.py
@@ -1112,7 +1112,9 @@ class TestLinearSearchFunctions:
             "pyimcom.imdestripe.cost_function", return_value=(100.0, np.zeros((2, 4, 4), dtype=np.float32))
         ), mock.patch(
             "pyimcom.imdestripe.residual_function", return_value=np.ones_like(p.params)
-        ), mock.patch("pyimcom.imdestripe.t0_global", 0.0):
+        ), mock.patch("pyimcom.imdestripe.t0_global", 0.0), pytest.warns(
+            RuntimeWarning, match=r"divide by zero encountered in scalar divide"
+        ):
             out = imdestripe.linear_search_general(
                 p,
                 direction,

--- a/tests/pyimcom/test_imsubtract.py
+++ b/tests/pyimcom/test_imsubtract.py
@@ -220,7 +220,7 @@ def test_fftconvolve_multi():
     assert np.allclose(x1, x2)
 
 
-def test_run_imsubtract_all(tmp_path, config_file=IMSUBTRACT_CONFIG):
+def _run_imsubtract_all(tmp_path, config_file, test2x2=False):
     """
     Test the run_imsubtract_all function.
     This test runs the imsubtract pipeline on a small set of images specified in the config file,
@@ -298,6 +298,7 @@ def test_run_imsubtract_all(tmp_path, config_file=IMSUBTRACT_CONFIG):
         display="/dev/null",
         max_layers=1,
         mmap=tmp_mmap,
+        bin2x2=test2x2,
     )
     with fits.open(f"{tmp_imsub}/r1_00013912_17_subI.fits") as f:
         single_run = np.copy(f[0].data[0, :, :])
@@ -305,7 +306,7 @@ def test_run_imsubtract_all(tmp_path, config_file=IMSUBTRACT_CONFIG):
     # full multi run
     # I set the number of workers to 1 (which is kind of silly) to stay within the footprint of
     # the free GitHub runner during tests.
-    run_imsubtract_all(config_file, workers=1, max_imgs=2, display="/dev/null", mmap=tmp_mmap)
+    run_imsubtract_all(config_file, workers=1, max_imgs=2, display="/dev/null", mmap=tmp_mmap, bin2x2=test2x2)
 
     # Check for outputs:
     expected_files = [f"{tmp_imsub}/r1_00013912_17_subI.fits", f"{tmp_imsub}/r1_00000670_12_subI.fits"]
@@ -313,6 +314,7 @@ def test_run_imsubtract_all(tmp_path, config_file=IMSUBTRACT_CONFIG):
         assert os.path.isfile(fname), f"Expected output file {fname} not found."
 
     # Check that the output files have the expected properties
+    ik = 0
     for fname in expected_files:
         m = re.search(r"r1_(\d{8})_(\d{2})_subI\.fits", fname)
         obsid = int(m.group(1))
@@ -342,11 +344,19 @@ def test_run_imsubtract_all(tmp_path, config_file=IMSUBTRACT_CONFIG):
             expected_diff_cutout = f[0].data
             ymin, ymax = f[0].header["YSTART"], f[0].header["YSTOP"]
             xmin, xmax = f[0].header["XSTART"], f[0].header["XSTOP"]
+            print(f[0].header)
 
         diff_cutout = diff[ymin:ymax, xmin:xmax]
+        atol = np.array([1.1e-3, 2.0e-2])[ik] if test2x2 else 1.0e-6
         assert np.allclose(
-            diff_cutout, expected_diff_cutout, atol=1e-6
+            diff_cutout, expected_diff_cutout, atol=atol
         ), f"Diff cutout for {fname} does not match expected values."
+        if test2x2:
+            print(np.amax(np.abs(diff_cutout[8:-8, 8:-8] - expected_diff_cutout[8:-8, 8:-8])))
+            assert np.allclose(
+                diff_cutout[8:-8, 8:-8], expected_diff_cutout[8:-8, 8:-8], atol=np.array([9.0e-4, 1.2e-2])[ik]
+            ), f"Diff cutout for {fname} does not match expected values."
+        ik += 1  # noqa: SIM113
 
     # compare "single" to "all" case
     with fits.open(f"{tmp_imsub}/r1_00013912_17_subI.fits") as f:
@@ -356,7 +366,7 @@ def test_run_imsubtract_all(tmp_path, config_file=IMSUBTRACT_CONFIG):
 
     # original wrapper
     os.remove(str(tmp_imsub) + "/r1_00013912_17_subI.fits")
-    run_imsubtract(config_file, display=f"{tmp_figs}/win", scanum=17, max_layers=1)
+    run_imsubtract(config_file, display=f"{tmp_figs}/win", scanum=17, max_layers=1, bin2x2=test2x2)
     with fits.open(f"{tmp_imsub}/r1_00013912_17_subI.fits") as f:
         assert np.allclose(f[0].data[0, :, :], multi_run, rtol=1.0e-6, atol=1.0e-6)
     fname = f"{tmp_figs}/win_13912_17_35_02.png"
@@ -373,6 +383,16 @@ def test_run_imsubtract_all(tmp_path, config_file=IMSUBTRACT_CONFIG):
     shutil.rmtree(tmp_imsub)
     shutil.rmtree(tmp_mmap)
     shutil.rmtree(tmp_figs)
+
+
+def test_run_imsubtract_all2(tmp_path):
+    """Test with 2x2 bin version."""
+    _run_imsubtract_all(tmp_path, IMSUBTRACT_CONFIG, test2x2=True)
+
+
+def test_run_imsubtract_all(tmp_path):
+    """Basic version of test."""
+    _run_imsubtract_all(tmp_path, IMSUBTRACT_CONFIG)
 
 
 def test_staticmethods():

--- a/tests/pyimcom/test_imsubtract.py
+++ b/tests/pyimcom/test_imsubtract.py
@@ -7,7 +7,7 @@ import urllib.request
 import numpy as np
 from astropy.io import fits
 from pyimcom.config import Config
-from pyimcom.splitpsf.imsubtract import fftconvolve_multi, get_wcs, pltshow, run_imsubtract
+from pyimcom.splitpsf.imsubtract import fftconvolve_multi, get_wcs, pltshow, reinterp, run_imsubtract
 from pyimcom.splitpsf.imsubtract_wrapper import run_imsubtract_all, run_imsubtract_single
 from pyimcom.splitpsf.splitpsf import SplitPSF, split_psf_to_fits
 from pyimcom.splitpsf.splitpsf_wrapper import split_psf_single
@@ -16,6 +16,26 @@ from scipy.signal import fftconvolve
 PSF_FILE = "https://github.com/Roman-HLIS-Cosmology-PIT/pyimcom/wiki/test-files/psf_test.fits"
 IMSUBTRACT_CONFIG = "https://github.com/Roman-HLIS-Cosmology-PIT/pyimcom/wiki/test-files/imsubtract/test_imsubtract_config.json"
 IMSUBTRACT_INPUT_PATH = "https://github.com/Roman-HLIS-Cosmology-PIT/pyimcom/wiki/test-files/imsubtract"
+
+
+def test_reinterp():
+    """Test interpolation function."""
+
+    n = 40
+    u = 2
+    v = 5
+    s_ = np.linspace(0, 2.0 * np.pi * (1 - 1 / n), n)
+    s2_ = np.linspace(2.0 * np.pi * 1.5 / n, 2.0 * np.pi * (1 - 2.5 / n), n // 2 - 1)
+    x, y = np.meshgrid(s_, s_)
+    x2, y2 = np.meshgrid(s2_, s2_)
+    arr = np.cos(u * x + v * y)
+    arr2 = reinterp(arr)
+    arr2_alt = np.sum(arr[1:-1, 1:-1].reshape((n // 2 - 1, 2, n // 2 - 1, 2)), axis=(-3, -1))
+    target = 4 * np.cos(u * x2 + v * y2)
+    er2_alt = np.amax(np.abs(arr2_alt - target))
+    er2 = np.amax(np.abs(arr2 - target))
+    assert er2 < 0.04
+    assert er2 < 0.2 * er2_alt
 
 
 def test_altwcs(tmp_path):

--- a/tests/pyimcom/test_imsubtract.py
+++ b/tests/pyimcom/test_imsubtract.py
@@ -323,6 +323,24 @@ def _run_imsubtract_all(tmp_path, config_file, test2x2=False):
     )
     with fits.open(f"{tmp_imsub}/r1_00013912_17_subI.fits") as f:
         single_run = np.copy(f[0].data[0, :, :])
+    # alt single run with wcs_shortcut turned off
+    run_imsubtract_single(
+        Config(config_file),
+        17,
+        13912,
+        tmp_imsub,
+        "r1_00013912_17.fits",
+        display="/dev/null",
+        wcs_shortcut=False,
+        max_layers=1,
+        mmap=tmp_mmap,
+        bin2x2=test2x2,
+    )
+    with fits.open(f"{tmp_imsub}/r1_00013912_17_subI.fits") as f:
+        single_run_alt = np.copy(f[0].data[0, :, :])
+    p99_single = np.percentile(np.abs(single_run), 99)
+    p99_diff = np.percentile(np.abs(single_run - single_run_alt), 99)
+    assert p99_diff < 0.01 * p99_single  # require the 2 versions to have only a small difference
 
     # full multi run
     # I set the number of workers to 1 (which is kind of silly) to stay within the footprint of

--- a/tests/pyimcom/test_imsubtract.py
+++ b/tests/pyimcom/test_imsubtract.py
@@ -5,6 +5,7 @@ import subprocess
 import urllib.request
 
 import numpy as np
+import pytest
 from astropy.io import fits
 from pyimcom.config import Config
 from pyimcom.splitpsf.imsubtract import fftconvolve_multi, get_wcs, pltshow, reinterp, run_imsubtract
@@ -452,3 +453,96 @@ def test_pltshow():
     assert plot.calls == 1
     pltshow(plot, "/dev/null")
     assert plot.calls == 1
+
+
+def test_imsubtract_exceptions(tmp_path):
+    """Test that the correct exceptions are raised in imsubtract."""
+
+    tmp_dir = str(tmp_path)
+    tmp_imsub = tmp_dir + "/temp_imsubtract"
+    tmp_mmap = tmp_dir + "/temp_mmap"
+    tmp_figs = tmp_dir + "/temp_figs"
+    # make temp_imsub directory
+    os.makedirs(tmp_imsub, exist_ok=True)
+    os.makedirs(tmp_imsub + "/blocks", exist_ok=True)
+    os.makedirs(tmp_mmap, exist_ok=True)
+    os.makedirs(tmp_figs, exist_ok=True)
+
+    urllib.request.urlretrieve(IMSUBTRACT_CONFIG, tmp_imsub + "/test_imsubtract_config.json")
+    config_file = tmp_imsub + "/test_imsubtract_config.json"
+
+    # read cache files into tmp_imsub
+    cache_files = [
+        "r1_00013912_17.fits.gz",
+        "r1_00000670_12.fits.gz",
+        "r1_00013912_17_wcs.asdf",
+        "r1_00000670_12_wcs.asdf",
+    ]
+    for filename in cache_files:
+        cf_url = IMSUBTRACT_INPUT_PATH + "/cache/" + filename
+        cf_local = os.path.join(tmp_imsub, filename)
+        urllib.request.urlretrieve(cf_url, cf_local)
+        if cf_local[-3:] == ".gz":
+            subprocess.run(["gunzip", cf_local])  # files on wiki were gzipped
+
+    # psf files
+    tmp_psf = tmp_imsub + "/r1.psf"
+    os.makedirs(tmp_psf, exist_ok=True)
+    for filename in ["psf_13912.fits", "psf_670.fits"]:
+        cf_url = IMSUBTRACT_INPUT_PATH + "/cache/r1.psf/" + filename
+        cf_local = os.path.join(tmp_psf, filename)
+        urllib.request.urlretrieve(cf_url, cf_local)
+
+        # now mess with these files to trigger exceptions
+        with fits.open(cf_local, mode="update") as f:
+            print(f[0].header["OVSAMP"])
+            f[0].header["OVSAMP"] = 7
+
+    with open(config_file, "r") as f:
+        cfg_text = f.read()
+    cfg_text = cfg_text.replace("$TMPDIR", tmp_dir)
+    cfg_text = cfg_text.replace("$CACHE", tmp_imsub + "/r1")
+    cfg_text = cfg_text.replace(
+        "https://github.com/Roman-HLIS-Cosmology-PIT/pyimcom/wiki/test-files/imsubtract/blocks/im3x2-H1",
+        tmp_imsub + "/blocks/im3x2-H1",
+    )
+    with open(config_file, "w") as f:
+        f.write(cfg_text)
+
+    # single run (this ensures that the codecov tracking works since it doesn't follow subprocesses)
+    with pytest.raises(ValueError, match=r"oversamp, oversamp=7"):
+        run_imsubtract_single(
+            Config(config_file),
+            17,
+            13912,
+            tmp_imsub,
+            "r1_00013912_17.fits",
+            display="/dev/null",
+            max_layers=1,
+            mmap=tmp_mmap,
+            bin2x2=True,
+        )
+
+    # this will raise a different exception
+    for filename in ["psf_13912.fits", "psf_670.fits"]:
+        cf_local = os.path.join(tmp_psf, filename)
+        with fits.open(cf_local, mode="update") as f:
+            print(f[0].header["OVSAMP"])
+            f[0].header["OVSAMP"] = 3
+    with pytest.raises(ValueError, match=r"oversamp=3 is odd, not consistent with bin2x2"):
+        run_imsubtract_single(
+            Config(config_file),
+            17,
+            13912,
+            tmp_imsub,
+            "r1_00013912_17.fits",
+            display="/dev/null",
+            max_layers=1,
+            mmap=tmp_mmap,
+            bin2x2=True,
+        )
+
+    # remove files from this test to save space
+    shutil.rmtree(tmp_imsub)
+    shutil.rmtree(tmp_mmap)
+    shutil.rmtree(tmp_figs)

--- a/tests/pyimcom/test_integratedimdestripe.py
+++ b/tests/pyimcom/test_integratedimdestripe.py
@@ -5,15 +5,21 @@ import os
 import re
 import shutil
 import sys
+import warnings
 from urllib.request import urlretrieve
 
 import asdf
 import numpy as np
+from asdf.exceptions import AsdfConversionWarning, AsdfPackageVersionWarning
 from astropy.io import fits
 from pyimcom import imdestripe
 from pyimcom.config import Config
 from pyimcom.config import Settings as Stn
 from pyimcom.wcsutil import LocWCS
+
+# disable some asdf warnings
+warnings.filterwarnings("ignore", category=AsdfConversionWarning)
+warnings.filterwarnings("ignore", category=AsdfPackageVersionWarning)
 
 # Example configuration file.
 # Note that we will replace $TMPDIR.

--- a/tests/pyimcom/test_splitpsf_driver.py
+++ b/tests/pyimcom/test_splitpsf_driver.py
@@ -68,7 +68,7 @@ myCfg_format = """
 """
 
 
-def splitpsf_driver(tmp_path, splitzeta):
+def splitpsf_driver(tmp_path, savezeta):
     """Main test function."""
 
     # first, get the configuration file.
@@ -116,7 +116,7 @@ def splitpsf_driver(tmp_path, splitzeta):
     )
 
     # run PSF splitting
-    splitpsf.main(str(tmp_path / "cfg.txt"))
+    splitpsf.main(str(tmp_path / "cfg.txt"), savezeta=savezeta)
 
     # check that we have the files we should have
     assert os.path.exists(str(tmp_path) + "/cache/in.psf/psf_34.fits")
@@ -148,11 +148,11 @@ def splitpsf_driver(tmp_path, splitzeta):
             assert np.shape(f[sca + 36].data) == (4, 384, 384)
 
 
-def test_splitpsf_driver_withsplitzeta(tmp_path):
+def test_splitpsf_driver_withsavezeta(tmp_path):
     """Test with splitzeta."""
     splitpsf_driver(tmp_path, True)
 
 
-def test_splitpsf_driver_nosplitzeta(tmp_path):
+def test_splitpsf_driver_nosavezeta(tmp_path):
     """Test with splitzeta."""
     splitpsf_driver(tmp_path, False)

--- a/tests/pyimcom/test_splitpsf_driver.py
+++ b/tests/pyimcom/test_splitpsf_driver.py
@@ -68,7 +68,7 @@ myCfg_format = """
 """
 
 
-def test_splitpsf_driver(tmp_path):
+def splitpsf_driver(tmp_path, splitzeta):
     """Main test function."""
 
     # first, get the configuration file.
@@ -146,3 +146,13 @@ def test_splitpsf_driver(tmp_path):
             assert 3e-5 < m_s < 8e-5
             print(sca, s_s, m_s)
             assert np.shape(f[sca + 36].data) == (4, 384, 384)
+
+
+def test_splitpsf_driver_withsplitzeta(tmp_path):
+    """Test with splitzeta."""
+    splitpsf_driver(tmp_path, True)
+
+
+def test_splitpsf_driver_nosplitzeta(tmp_path):
+    """Test with splitzeta."""
+    splitpsf_driver(tmp_path, False)

--- a/tests/pyimcom/test_splitpsf_exception.py
+++ b/tests/pyimcom/test_splitpsf_exception.py
@@ -77,3 +77,14 @@ def test_mainexcept(tmp_path):
 
     with pytest.raises(KeyError, match=r"INLAYERCACHE"):
         splitpsf.main(str(tmp_path / "cfg2.txt"))
+
+    # now, get a nonexistent path
+    with open(tmp_path / "cfg3.txt", "w") as f:
+        f.write(
+            myCfg2_format.replace("$TMPDIR", str(tmp_path) + "/doesntexist/doesntexist/doesntexist")
+            .replace("$KEY", "INLAYERCACHE")
+            .replace("AIRYOBSC", "GAUSSIAN")
+        )
+
+    with pytest.raises(OSError):
+        splitpsf.main(str(tmp_path / "cfg3.txt"))

--- a/tests/pyimcom/test_splitpsf_exception.py
+++ b/tests/pyimcom/test_splitpsf_exception.py
@@ -1,0 +1,79 @@
+"""Exception testing."""
+
+import pytest
+from pyimcom.splitpsf import splitpsf
+
+myCfg2_format = """
+{
+    "OBSFILE": "$TMPDIR/obs.fits",
+    "INDATA": [
+        "$TMPDIR/in",
+        "L2_2506"
+    ],
+    "CTR": [
+        60.0504,
+        -3.8
+    ],
+    "LONPOLE": 240.0,
+    "OUTSIZE": [
+        4,
+        25,
+        0.04
+    ],
+    "BLOCK": 2,
+    "FILTER": 1,
+    "LAKERNEL": "Cholesky",
+    "KAPPAC": [
+         5e-4
+    ],
+    "INPSF": [
+        "$TMPDIR/psf",
+        "L2_2506",
+        6
+    ],
+    "EXTRAINPUT": [
+        "gsstar14",
+        "gsext14,seed=100,shear=-.01:0.017320508075688773",
+        "cstar14",
+        "nstar14,2e5,100,256",
+        "whitenoise1",
+        "1fnoise2",
+        "gsext14,n=0.5,hlr=0.1,shape=0.2:0.1,shear=0.05:-0.12",
+        "gstrstar14"
+    ],
+    "PSFSPLIT": [
+        4.0,
+        9.0,
+        0.01
+    ],
+    "PADSIDES": "all",
+    "OUTMAPS": "USTKN",
+    "OUT": "$TMPDIR/out/testout_F",
+    "INPAD": 0.8,
+    "NPIXPSF": 42,
+    "FADE": 1,
+    "PAD": 0,
+    "NOUT": 1,
+    "OUTPSF": "AIRYOBSC",
+    "EXTRASMOOTH": 0.9265328730414752,
+    "$KEY": "$TMPDIR/cache/in"
+}
+"""
+
+
+def test_mainexcept(tmp_path):
+    """Test for the right exceptions getting raised when we give bad values."""
+
+    # first, get the configuration file with INLAYERCACHE
+    with open(tmp_path / "cfg.txt", "w") as f:
+        f.write(myCfg2_format.replace("$TMPDIR", str(tmp_path)).replace("$KEY", "INLAYERCACHE"))
+
+    with pytest.raises(ValueError, match=r"Gaussian"):
+        splitpsf.main(str(tmp_path / "cfg.txt"))
+
+    # now, get the configuration file with no INLAYERCACHE
+    with open(tmp_path / "cfg2.txt", "w") as f:
+        f.write(myCfg2_format.replace("$TMPDIR", str(tmp_path)))
+
+    with pytest.raises(KeyError, match=r"INLAYERCACHE"):
+        splitpsf.main(str(tmp_path / "cfg2.txt"))


### PR DESCRIPTION
Addresses #118 (although with a different method).

This enables an option in the configuration (`true` as an additional field at the end of `PSFSPLIT`) that runs the kernel convolution / subtraction at half the resolution.

I'm running a small test on OSC that seems to be going well / not introducing any changes that look significant; I'll do a full-scale mosaic (repeat of H1) all the way through to the report before marking this ready to merge.