### PR TITLE
add weight map

### DIFF
--- a/docs/output_README.rst
+++ b/docs/output_README.rst
@@ -46,6 +46,7 @@ There are several options for reading PyIMCOM output files. From "lowest" to "hi
     sci_image = my_block.get_coadded_layer('SCI')
     # extracts a metadata map
     fidelity_map = my_block.get_output_map('FIDELITY') # options are: 'FIDELITY', 'SIGMA', 'KAPPA', 'INTWTSUM', 'EFFCOVER'
+    # computes an inverse variance map
     weight_map = my_block.get_weight_map("noise,Rz4PbrS2C2") #Generate inverse variance weight map according to Appendix A of 2607.09849.
 
 * The ``pyimcom.meta.distortimage.MetaMosaic`` class is the highest-level interface and constructs a sub-mosaic

--- a/docs/output_README.rst
+++ b/docs/output_README.rst
@@ -46,6 +46,7 @@ There are several options for reading PyIMCOM output files. From "lowest" to "hi
     sci_image = my_block.get_coadded_layer('SCI')
     # extracts a metadata map
     fidelity_map = my_block.get_output_map('FIDELITY') # options are: 'FIDELITY', 'SIGMA', 'KAPPA', 'INTWTSUM', 'EFFCOVER'
+    weight_map = my_block.get_weight_map("noise,Rz4PbrS2C2") #Generate inverse variance weight map according to Appendix A of 2607.09849.
 
 * The ``pyimcom.meta.distortimage.MetaMosaic`` class is the highest-level interface and constructs a sub-mosaic
   from the 3x3 set of blocks centered on the specified file. It can be subarrayed, sheared, masked, etc.:

--- a/src/pyimcom/analysis.py
+++ b/src/pyimcom/analysis.py
@@ -119,6 +119,7 @@ class OutImage:
         if cfg is None:
             with ReadFile(fpath) as hdu_list:
                 self.cfg = Config("".join(hdu_list["CONFIG"].data["text"].tolist()))
+                self.header = hdu_list[0].header
         self.cfg()  # update configuration parameters
 
         self.hdu_names = hdu_names
@@ -534,6 +535,30 @@ class OutImage:
                 my_maps[my_slice] * add_mode + ur_maps[ur_slice], coef, dtype
             )
             del my_maps, ur_maps, my_slice, ur_slice
+
+    def get_weight_map(self, _noise_layer) -> np.array:
+        """
+        Generate inverse variance weight map according to Appendix A of 2607.09849.
+
+        Parameters
+        ----------
+        outmap : str
+            Name of the output map to be extracted.
+        _noise_layer: str
+            Name of the noise layer
+
+        Returns
+        -------
+        data : np.array
+            Inverse variance map. shape is (NsideP, NsideP)
+        """
+        noise_image = self.get_coadded_layer(_noise_layer)
+        Sigma = self.get_output_map("SIGMA")
+        scalefactor = np.sum(np.square(noise_image))
+        # Background-only (correlated) variance — source shot noise excluded.
+        corr_var    = (scalefactor / np.sum(Sigma)) * Sigma
+        wht         = np.where(corr_var > 0, 1.0 / corr_var, 0.)
+        return wht 
 
 
 class NoiseAnal:

--- a/src/pyimcom/analysis.py
+++ b/src/pyimcom/analysis.py
@@ -542,8 +542,6 @@ class OutImage:
 
         Parameters
         ----------
-        outmap : str
-            Name of the output map to be extracted.
         _noise_layer: str
             Name of the noise layer
 
@@ -552,13 +550,16 @@ class OutImage:
         data : np.array
             Inverse variance map. shape is (NsideP, NsideP)
         """
+
         noise_image = self.get_coadded_layer(_noise_layer)
-        Sigma = self.get_output_map("SIGMA") # Sigma is S_\alpha \equiv \sum_i \left(T_\alpha^i\right)^2 defined in A9 of 2607.09849 or the noise amplication map in 2410.05442 
+        Sigma = self.get_output_map("SIGMA")
+        # Sigma is S_\alpha \equiv \sum_i \left(T_\alpha^i\right)^2 defined in
+        # Eq. (A9) of 2607.09849 or the noise amplication map in 2410.05442
         scalefactor = np.sum(np.square(noise_image))
         # Background-only (correlated) variance — source shot noise excluded.
-        corr_var    = (scalefactor / np.sum(Sigma)) * Sigma
-        wht         = np.where(corr_var > 0, 1.0 / corr_var, 0.)
-        return wht 
+        corr_var = (scalefactor / np.sum(Sigma)) * Sigma
+        wht = np.where(corr_var > 0, 1.0 / corr_var, 0.0)
+        return wht
 
 
 class NoiseAnal:

--- a/src/pyimcom/analysis.py
+++ b/src/pyimcom/analysis.py
@@ -553,7 +553,7 @@ class OutImage:
             Inverse variance map. shape is (NsideP, NsideP)
         """
         noise_image = self.get_coadded_layer(_noise_layer)
-        Sigma = self.get_output_map("SIGMA")
+        Sigma = self.get_output_map("SIGMA") # Sigma is S_\alpha \equiv \sum_i \left(T_\alpha^i\right)^2 defined in A9 of 2607.09849 or the noise amplication map in 2410.05442 
         scalefactor = np.sum(np.square(noise_image))
         # Background-only (correlated) variance — source shot noise excluded.
         corr_var    = (scalefactor / np.sum(Sigma)) * Sigma

--- a/tests/pyimcom/test_pyimcom.py
+++ b/tests/pyimcom/test_pyimcom.py
@@ -927,6 +927,13 @@ def test_PyIMCOM_run1(tmp_path, setup):
     assert np.amax(outfidelity) < 1.0e-5
     assert np.shape(outfidelity) == (100, 100)
 
+    # Test for get_weight_map
+    wht = my_block.get_weight_map("whitenoise1")
+    assert np.shape(wht) == (100, 100)
+    assert 5.7 < np.amin(wht) < 5.8
+    assert 6.7 < np.amax(wht) < 6.9
+    del wht
+
     ## Configuration test ##
 
     with fits.open(tmp_path / "out/testout_F_00_01.fits") as fblock:


### PR DESCRIPTION
Hi, 
I added a function (get_weight_map) to the OutImage class that generates an inverse-variance weight map according to Appendix A of 2607.09849.  
The weight map can be obtained by 
```
outimage.get_weight_map("noise,Rz4PbrS2C2")
```