### PR TITLE
piff format and drawing with alternate PSFs

### DIFF
--- a/docs/config_README.rst
+++ b/docs/config_README.rst
@@ -108,7 +108,7 @@ The current format for the FITS file is that HDU #1 is a binary table with colum
 The coordinate and filter information is needed for PyIMCOM to select the appropriate exposures for use in each block. (It is not used for precision alignment of the images: for that, PyIMCOM uses the WCS provided in the input files.) The date information is not used right now, but it could be used in the future to build co-adds in deep fields that correspond to certain ranges of epochs.
 
 INDATA: The input observations
------------------------------------
+------------------------------
 
 This has two entries containing the directory to find input images and the format:
 
@@ -130,7 +130,7 @@ More input formats will be added as needed to support further simulations and Ro
 
 
 FILTER: Filter choice
----------------------------
+---------------------
 
 This is a simple integer for the filter to coadd:
 
@@ -141,7 +141,7 @@ This is a simple integer for the filter to coadd:
 Convention is 0 (W146), 1 (F184), 2 (H158), 3 (J129), 4 (Y106), 5 (Z087), 6 (R062), and 10 (K213). (7, 8, and 9 are codes for the prism, dark, and grism, and are not supported.)
 
 INPSF: Input PSF files
------------------------------
+----------------------
 
 This is a list containing a directory, PSF format, and oversampling factor:
 
@@ -154,10 +154,19 @@ This is a list containing a directory, PSF format, and oversampling factor:
 
 The above example looks for PSFs in the directory ``/fs/scratch/PCON0003/cond0007/anl-run-in-prod/psf_vlarge``; has PSF format type ``anlsim``; and the PSF is oversampled relative to native pixels by a factor of 8.
 
-The valid PSF formats are the same as the input data formats in the `INDATA <INDATA: The input observations>`_ keyword. Most of the time, you will want to use the same format as in ``INDATA``, but this is not enforced.
+The valid PSF formats are the same as the input data formats in the `INDATA <INDATA: The input observations>`_ keyword. In addition, it is possible to read from a Piff file:
+
+.. code-block:: json
+
+    "INPSF": [
+       "/fs/scratch/PCON0003/cond0007/anl-run-in-prod/",
+       "piff:myfiles",
+       8]
+
+where here, e.g., the PSF file for obsid=2500 would be in ``/fs/scratch/PCON0003/cond0007/anl-run-in-prod/myfiles_2500.piff``. This option is only available if Piff is installed (otherwise you will get a ``ModuleNotFoundError``).
 
 PSFSPLIT: Splitting the PSF\*
--------------------------------
+-----------------------------
 
 This keyword is optional (it defaults to ``None``). If provided, it means that the ``pyimcom.splitpsf`` module has been used to split the PSF into long- and short-range parts, which will (eventually) allow for iterative cleaning of the long-range part of the PSF. An example is:
 

--- a/src/pyimcom/coadd.py
+++ b/src/pyimcom/coadd.py
@@ -17,7 +17,6 @@ Block
 import datetime
 import gc
 import sys
-import time
 from itertools import combinations, product
 from os.path import exists
 from pathlib import Path

--- a/src/pyimcom/coadd.py
+++ b/src/pyimcom/coadd.py
@@ -82,6 +82,15 @@ class InImage:
     get_psf_pos
         Get input PSF array at given position.
 
+    Notes
+    -----
+    This class stores the loaded PSF data in memory. To enable the ``INPSFDRAW`` option, we
+    have a ``._mode`` attribute that could be:
+
+    - ``None`` (nothing loaded)
+    - ``False`` (coaddition PSF is loaded)
+    - ``True`` (draw PSF is loaded)
+
     """
 
     def __init__(self, blk: "Block", idsca: tuple[int, int]) -> None:
@@ -100,6 +109,8 @@ class InImage:
             if self.infile[-5:] == ".asdf":
                 with asdf.open(self.infile) as f:
                     self.inwcs = PyIMCOM_WCS(f["roman"]["meta"]["wcs"])
+
+        self._mode = None
 
     @staticmethod
     def generate_idx_grid(xs: np.array, ys: np.array) -> np.array:
@@ -411,6 +422,10 @@ class InImage:
             del self.inpsf_arr
         if hasattr(self, "inpsf_cube"):
             del self.inpsf_cube
+        if hasattr(self, "inpsf_piff"):
+            del self.inpsf_piff
+
+        self._mode = None  # nothing loaded anymore
 
     @staticmethod
     def smooth_and_pad(inArray: np.array, tophatwidth: float = 0.0, gaussiansigma: float = 0.0) -> np.array:
@@ -556,13 +571,27 @@ class InImage:
         # pixloc = self.inwcs.all_world2pix(np.array([[*psf_compute_point]]).astype(np.float64), 0)[0]
         pixloc = self.inwcs.all_world2pix(psf_compute_point[0], psf_compute_point[1], 0)
 
-        if self.blk.cfg.inpsf_format == "dc2_imsim":
+        # what to draw
+        use_drawpsf = use_drawpsf and (self.blk.cfg.inpsfdraw_format is not None)
+        iformat, ipath, ioversamp = (
+            self.blk.cfg.inpsf_format,
+            self.blk.cfg.inpsf_path,
+            self.blk.cfg.inpsf_oversamp,
+        )
+        if use_drawpsf:
+            iformat, ipath, ioversamp = (
+                self.blk.cfg.inpsfdraw_format,
+                self.blk.cfg.inpsfdraw_path,
+                self.blk.cfg.inpsfdraw_oversamp,
+            )
+        # clear if the wrong mode is cached
+        if self._mode == (not use_drawpsf):
+            self.clear()
+
+        # now the various options
+        if iformat == "dc2_imsim":
             if not hasattr(self, "inpsf_arr"):
-                fname = (
-                    self.blk.cfg.inpsf_path
-                    + "/"
-                    + InImage.psf_filename(self.blk.cfg.inpsf_format, self.idsca[0])
-                )
+                fname = ipath + "/" + InImage.psf_filename(iformat, self.idsca[0])
                 assert exists(fname), "Error: input psf does not exist"
                 with fitsio.FITS(fname) as fileh:
                     self.inpsf_arr = InImage.smooth_and_pad(
@@ -571,13 +600,9 @@ class InImage:
 
             this_psf = self.inpsf_arr
 
-        elif self.blk.cfg.inpsf_format == "anlsim" or self.blk.cfg.inpsf_format == "L2_2506":
+        elif iformat in ["anlsim", "L2_2506"]:
             if not hasattr(self, "inpsf_cube"):
-                fname = (
-                    self.blk.cfg.inpsf_path
-                    + "/"
-                    + InImage.psf_filename(self.blk.cfg.inpsf_format, self.idsca[0])
-                )
+                fname = ipath + "/" + InImage.psf_filename(iformat, self.idsca[0])
                 sskip = 0
                 readskip = False
                 if use_shortrange and self.blk.cfg.psfsplit:
@@ -594,7 +619,7 @@ class InImage:
             lporder = int(np.round(np.sqrt(np.shape(self.inpsf_cube)[0]))) - 1
             lpoly = InImage.LPolyArr(lporder, (pixloc[0] - 2043.5) / 2044.0, (pixloc[1] - 2043.5) / 2044.0)
             # pixels are in C/Python convention since pixloc was set this way
-            if self.blk.cfg.inpsf_format == "anlsim":
+            if iformat == "anlsim":
                 this_psf = (
                     InImage.smooth_and_pad(
                         np.einsum("a,aij->ij", lpoly, self.inpsf_cube), tophatwidth=tophatwidth_use
@@ -609,38 +634,17 @@ class InImage:
                 )
                 # L2_2506 and later are per (s_in/ovsamp)**2
 
-        elif self.blk.cfg.inpsf_format[:4].lower() == "piff":
+        elif iformat[:4].lower() == "piff":
             if not hasattr(self, "inpsf_piff"):
-                fname = (
-                    self.blk.cfg.inpsf_path
-                    + "/"
-                    + InImage.psf_filename(self.blk.cfg.inpsf_format, self.idsca[0])
-                )
+                fname = ipath + "/" + InImage.psf_filename(iformat, self.idsca[0])
                 assert exists(fname), "Error: input psf does not exist"
                 self.inpsf_piff = PiffPSFModel(fname, self.idsca[1])
-            this_psf = self.inpsf_piff.draw(pixloc[0], pixloc[1], oversamp=self.blk.cfg.inpsf_oversamp)
+            this_psf = self.inpsf_piff.draw(pixloc[0], pixloc[1], oversamp=ioversamp)
 
         else:
             raise RuntimeError("Error: input psf does not exist")
 
-        # test of the astrometry, if requested
-        # if np.hypot(pixloc[0]-200, pixloc[1]-3000)<150:
-        #    print(':::', pixloc, psf_compute_point); sys.stdout.flush()
         return this_psf
-
-        # when distort_matrice is not required
-        # if dWdp_out is None: return this_psf
-
-        # get the distortion matrices d[(X,Y)perfect]/d[(X,Y)native]
-        # Note that rotations and magnifications are included in the distortion matrix, as well as shear
-        # Also the distortion is relative to the output grid, not to the tangent plane to the celestial sphere
-        # (although we really don't want the difference to be large ...)
-        # distort_matrice = np.linalg.inv(dWdp_out) \
-        #     @ wcs.utils.local_partial_pixel_derivatives(self.inwcs, pixloc[0], pixloc[1]) \
-        #     * self.blk.cfg.dtheta*Stn.degree/Stn.pixscale_native
-
-        # print(pixloc, self.blk.cfg.inpsf_oversamp, np.shape(this_psf), np.sum(this_psf))
-        # return this_psf, distort_matrice
 
 
 class InStamp:

--- a/src/pyimcom/coadd.py
+++ b/src/pyimcom/coadd.py
@@ -17,6 +17,7 @@ Block
 import datetime
 import gc
 import sys
+import time
 from itertools import combinations, product
 from os.path import exists
 from pathlib import Path
@@ -36,6 +37,8 @@ from astropy.io import fits
 from astropy.table import Table
 from filelock import FileLock, Timeout
 from scipy.special import legendre
+
+import pyimcom  # noqa: F401
 
 from .config import Config, Timer, format_axis, format_axis_pars
 from .config import Settings as Stn
@@ -586,7 +589,11 @@ class InImage:
             )
         # clear if the wrong mode is cached
         if self._mode == (not use_drawpsf):
-            self.clear()
+            if hasattr(self, "inpsf_cube"):
+                del self.inpsf_cube
+            if hasattr(self, "inpsf_piff"):
+                del self.inpsf_piff
+        self._mode = use_drawpsf  # will keep this cached
 
         # now the various options
         if iformat == "dc2_imsim":
@@ -639,7 +646,7 @@ class InImage:
                 fname = ipath + "/" + InImage.psf_filename(iformat, self.idsca[0])
                 assert exists(fname), "Error: input psf does not exist"
                 self.inpsf_piff = PiffPSFModel(fname, self.idsca[1])
-            this_psf = self.inpsf_piff.draw(pixloc[0], pixloc[1], oversamp=ioversamp)
+            this_psf = self.inpsf_piff.draw(pixloc[0], pixloc[1], stamp_size=48, oversamp=ioversamp)
 
         else:
             raise RuntimeError("Error: input psf does not exist")

--- a/src/pyimcom/coadd.py
+++ b/src/pyimcom/coadd.py
@@ -42,6 +42,7 @@ from .config import Settings as Stn
 from .lakernel import CholKernel, EigenKernel, EmpirKernel, IterKernel
 from .layer import Mask, check_if_idsca_exists, get_all_data
 from .psfutil import PSFGrp, PSFInterpolator, PSFOvl, SysMatA, SysMatB
+from .utils.piffutils import PiffPSFModel
 from .wcsutil import PyIMCOM_WCS
 
 
@@ -513,10 +514,15 @@ class InImage:
             return f"dc2_psf_{obsid:d}.fits"
         if inpsf_format in ["anlsim", "L2_2506"]:
             return f"psf_polyfit_{obsid:d}.fits"
+        if inpsf_format[:4].lower() == "piff":
+            s = inpsf_format[5:] if inpsf_format[4] == ":" else "ffov"
+            return f"{s}_{obsid:d}.piff"
 
         raise AssertionError("psf_filename: should not get here")
 
-    def get_psf_pos(self, psf_compute_point: np.array, use_shortrange: bool = False) -> np.array:
+    def get_psf_pos(
+        self, psf_compute_point: np.array, use_shortrange: bool = False, use_drawpsf: bool = False
+    ) -> np.array:
         """
         Get input PSF array at given position.
 
@@ -524,10 +530,13 @@ class InImage:
 
         Parameters
         ----------
-        psf_compute_point : np.array
+        psf_compute_point : np.ndarray
             Length 2 array, point to compute PSF in RA and Dec.
         use_shortrange : bool, optional
             If True and PSFSPLIT is set in the configuration file, then pulls only the short-range PSF G^(S).
+            (Only used with some INPSF formats.)
+        use_drawpsf : np.ndarray, optional
+            Use the PSF for drawing objects?
 
         Returns
         -------
@@ -599,6 +608,17 @@ class InImage:
                     np.einsum("a,aij->ij", lpoly, self.inpsf_cube), tophatwidth=tophatwidth_use
                 )
                 # L2_2506 and later are per (s_in/ovsamp)**2
+
+        elif self.blk.cfg.inpsf_format[:4].lower() == "piff":
+            if not hasattr(self, "inpsf_piff"):
+                fname = (
+                    self.blk.cfg.inpsf_path
+                    + "/"
+                    + InImage.psf_filename(self.blk.cfg.inpsf_format, self.idsca[0])
+                )
+                assert exists(fname), "Error: input psf does not exist"
+                self.inpsf_piff = PiffPSFModel(fname, self.idsca[1])
+            this_psf = self.inpsf_piff.draw(pixloc[0], pixloc[1], oversamp=self.blk.cfg.inpsf_oversamp)
 
         else:
             raise RuntimeError("Error: input psf does not exist")

--- a/src/pyimcom/config.py
+++ b/src/pyimcom/config.py
@@ -306,6 +306,9 @@ class Config:
         "inpsf_path",
         "inpsf_format",
         "inpsf_oversamp",
+        "inpsfdraw_path",
+        "inpsfdraw_format",
+        "inpsfdraw_oversamp",
         "psfsplit",
         "psfsplit_r1",
         "psfsplit_r2",
@@ -468,6 +471,10 @@ class Config:
         self.use_filter = cfg_dict["FILTER"]
         # input PSF information
         self.inpsf_path, self.inpsf_format, self.inpsf_oversamp = cfg_dict["INPSF"]
+        # separate "draw" PSF, if given
+        self.inpsfdraw_path, self.inpsfdraw_format, self.inpsfdraw_oversamp = cfg_dict.get(
+            "INPSFDRAW", (None, None, None)
+        )
         # if PSF splitting is used
         self.psfsplit = cfg_dict.get("PSFSPLIT", "")
         self.porder_imsubtract = cfg_dict.get("PORDER_IMSUBTRACT", -1)
@@ -658,6 +665,8 @@ class Config:
             "\n"
             "self.inpsf_oversamp = int(OVERSAMP)"
         )
+        # draw not enabled from CLI
+        self.inpsfdraw_path, self.inpsfdraw_format, self.inpsfdraw_oversamp = None, None, None
 
         print("# PSF splitting", flush=True)
         self._get_attrs_wrapper(
@@ -1117,6 +1126,8 @@ class Config:
         cfg_dict["INDATA"] = [self.inpath, self.informat]
         cfg_dict["FILTER"] = self.use_filter
         cfg_dict["INPSF"] = [self.inpsf_path, self.inpsf_format, self.inpsf_oversamp]
+        if self.inpsfdraw_path is not None:
+            cfg_dict["INPSFDRAW"] = [self.inpsfdraw_path, self.inpsfdraw_format, self.inpsfdraw_oversamp]
         if self.psfsplit:
             cfg_dict["PSFSPLIT"] = [
                 self.psfsplit_r1,

--- a/src/pyimcom/layer.py
+++ b/src/pyimcom/layer.py
@@ -244,7 +244,7 @@ class GalSimInject:
             if angleTransient and (qp[n] + s) % 2 == 1:
                 continue
 
-            psf = inpsf((my_ra[n], my_dec[n]))  # now with PSF variation
+            psf = inpsf((my_ra[n], my_dec[n]), use_drawpsf=True)  # now with PSF variation
             psf_image = galsim.Image(psf, scale=0.11 / inpsf_oversamp)
             # interp_psf = galsim.InterpolatedImage(psf_image, x_interpolant='lanczos32')
             # the first time, get the preferred stepk and maxk
@@ -584,7 +584,7 @@ class GalSimInject:
         t0 = time.time()
         for n in range(num_obj):
             if not chrom:
-                psf = inpsf((my_ra[n], my_dec[n]))  # now with PSF variation
+                psf = inpsf((my_ra[n], my_dec[n]), use_drawpsf=True)  # now with PSF variation
             else:
                 psf = GalSimInject.get_psf_pos(inpsf, mywcs, (my_ra[n], my_dec[n]), inpsf_oversamp)
             psf_image = galsim.Image(psf, scale=0.11 / inpsf_oversamp)
@@ -823,7 +823,7 @@ class GridInject:
         d = 64  # region to draw
 
         for istar in range(len(ipix)):
-            thispsf = inpsf((rapix[istar], decpix[istar]))  # now with PSF variation
+            thispsf = inpsf((rapix[istar], decpix[istar]), use_drawpsf=True)  # now with PSF variation
             this_xmax = min(nside_sca, int(xsca[istar]) + d)
             this_xmin = max(0, int(xsca[istar]) - d)
             this_ymax = min(nside_sca, int(ysca[istar]) + d)

--- a/src/pyimcom/utils/piffutils.py
+++ b/src/pyimcom/utils/piffutils.py
@@ -92,7 +92,7 @@ class PiffPSFModel:
                     chipnum=self.sca - 1, x=x, y=y, center=True, stamp_size=normbox, sca=self.sca
                 ).array
             )
-        return stamp
+        return stamp / oversamp**2  # PyIMCOM expects flux per sample, not per native pixel
 
 
 def piff_to_legendre(

--- a/src/pyimcom/utils/piffutils.py
+++ b/src/pyimcom/utils/piffutils.py
@@ -16,6 +16,85 @@ except ModuleNotFoundError:
     HAS_PIFF = False
 
 
+class PiffPSFModel:
+    """
+    Class to draw a Piff PSF, but keep the file loaded.
+
+    Paramters
+    ---------
+    psf_file : str
+        The path to the PSF file.
+    sca: int
+        The sca number at which to draw the PSF (range: 1 to 18, inclusive).
+
+    Methods
+    -------
+    draw
+        Draws the PSF at the indicated position.
+
+    """
+
+    def __init__(self, psf_file, sca):
+        if not HAS_PIFF:
+            raise ModuleNotFoundError("piff isn't installed. Please install it using 'pip install piff'.")
+
+        # First read the psf via piff from given file
+        self.psf = piff.read(psf_file)
+        self.sca = sca
+
+    def draw(self, x, y, stamp_size=128, oversamp=6, normbox=None):
+        """
+        Draws the PSF at the indicated position.
+
+        Parameters
+        ----------
+        x, y : float
+            The (x, y) position on the chip where we want the PSF.
+        stamp_size: int, optional
+            The size of the PSF stamp. Default is 128.
+        oversamp: int, optional
+            The oversampling factor for the PSF stamp. Default is 6.
+        legendre_order : int, optional
+            Polynomial order for Legendre polynomial expansion. Default is 5.
+        normbox : int, optional
+            If given, normalizes the PSF to integrate to 1 in the specified box size (which may be
+            different from the region size used in Piff; we envision it will be larger if the PSF has
+            far wings that are not re-fit by Piff, e.g., from a physical model or fit to scattered
+            light in stacked bright stars, etc.).
+
+        Returns
+        -------
+        stamp : np.ndarray of shape (stamp_size*oversamp, stamp_size*oversamp)
+            A postage stamp of the PSF.
+
+        """
+
+        stamp = np.zeros((stamp_size * oversamp, stamp_size * oversamp), dtype=np.float32)
+
+        # get sub-PSFs in each region
+        s = np.linspace(-0.5 + 0.5 / oversamp, 0.5 - 0.5 / oversamp, oversamp)
+        for j in range(oversamp):
+            for i in range(oversamp):
+                stamp[j::oversamp, i::oversamp] = self.psf.draw(
+                    chipnum=self.sca - 1,
+                    x=x,
+                    y=y,
+                    center=True,
+                    offset=(-s[i], -s[j]),
+                    stamp_size=stamp_size,
+                    sca=self.sca,
+                ).array
+
+        # normalization
+        if normbox is not None:
+            stamp[:, :] /= np.sum(
+                self.psf.draw(
+                    chipnum=self.sca - 1, x=x, y=y, center=True, stamp_size=normbox, sca=self.sca
+                ).array
+            )
+        return stamp
+
+
 def piff_to_legendre(
     psf_file,
     sca,

--- a/tests/pyimcom/test_piff.py
+++ b/tests/pyimcom/test_piff.py
@@ -294,4 +294,3 @@ def test_piff_decomposition(tmp_path):
     assert 0.017 < moms.observed_e2 < 0.021
 
     assert np.allclose(arr2, 1.0718 * arr3, atol=1e-5, rtol=1e-3)
-

--- a/tests/pyimcom/test_piff.py
+++ b/tests/pyimcom/test_piff.py
@@ -8,7 +8,7 @@ import galsim
 import numpy as np
 import pytest
 from astropy.io import fits
-from pyimcom.utils.piffutils import piff_to_legendre, piff_to_legendre_multi
+from pyimcom.utils.piffutils import PiffPSFModel, piff_to_legendre, piff_to_legendre_multi
 
 EXAMPLE_FILE = "https://github.com/Roman-HLIS-Cosmology-PIT/pyimcom/wiki/test-files/ffov_13906_17.piff"
 
@@ -276,3 +276,22 @@ def test_piff_decomposition(tmp_path):
             oversamp=4,
             legendre_order=1,
         )
+
+    # now check the PSF point model
+    p = PiffPSFModel(floc, 12)
+    arr1 = p.draw(0, 0, oversamp=6)
+    arr2 = p.draw(0, 4087, oversamp=6)
+    arr3 = p.draw(0, 4087, oversamp=6, normbox=16)
+
+    # Gaussian fit
+    moms = galsim.hsm.FindAdaptiveMom(galsim.Image(arr1))
+    print(moms.moments_sigma)
+    print(moms.moments_centroid.x, moms.moments_centroid.y)
+    print(moms.observed_e1, moms.observed_e2)
+    assert 0.68 < moms.moments_sigma / 6.0 < 0.72
+    assert np.hypot(moms.moments_centroid.x - 384.5, moms.moments_centroid.y - 384.5) < 0.6
+    assert 0.002 < moms.observed_e1 < 0.008
+    assert 0.017 < moms.observed_e2 < 0.021
+
+    assert np.allclose(arr2, 1.0718 * arr3, atol=1e-5, rtol=1e-3)
+

--- a/tests/pyimcom/test_pyimcom.py
+++ b/tests/pyimcom/test_pyimcom.py
@@ -758,7 +758,7 @@ def setup(tmp_path):
         cfgdict = json.loads(f.read())
     cfgdict["INPSFDRAW"][1] = "Piff:psf_temp"
     cfgdict["INPSFDRAW"][2] = 4  # 4x4 oversampling
-    cfgdict["OUT"] = str(tmp_path) + "/out/testout_F"
+    cfgdict["OUT"] = str(tmp_path) + "/out/testout_F_piff"
     cfgdict["EXTRAINPUT"] = ["gsstar12", "gsext12,seed=100,shear=-.5,0", "cstar12"]
     with open(tmp_path / "cfg_piff.txt", "w") as f:
         f.write(json.dumps(cfgdict))
@@ -785,8 +785,6 @@ def setup(tmp_path):
     # run one block of Piff
     cfg_piff = Config(tmp_path / "cfg_piff.txt")
     Block(cfg=cfg_piff, this_sub=1)
-    with open("cachedir.txt", "w") as f:
-        f.write(cachedir)
 
     # now clean up everything, including the input files
     for iobs in range(len(obs)):
@@ -916,6 +914,13 @@ def test_altdrawlayers(tmp_path, setup):
         dsig2 = moms.moments_sigma**2 - momsalt.moments_sigma**2
         q = 0.04 if simlayer == 2 else 0.01
         assert 0.09 - q < dsig2 * sc < 0.09 + q
+
+    # test Piff drew a correctly normalized star and galaxy
+    ys, xs = 3014, 3063
+    with fits.open("") as f:
+        for simlayer in range(1, 4):
+            sm = np.sum(f[0].data[simlayer, ys - 16 : ys + 17, xs - 16 : xs + 17])
+            assert 1.02 < sm < 1.2
 
 
 def test_PyIMCOM_run1(tmp_path, setup):

--- a/tests/pyimcom/test_pyimcom.py
+++ b/tests/pyimcom/test_pyimcom.py
@@ -28,7 +28,7 @@ from astropy.table import Table
 from furry_parakeet.pyimcom_croutines import gridD5512C
 from gwcs import coordinate_frames as cf
 from pyimcom.analysis import Mosaic, OutImage, Suite
-from pyimcom.coadd import Block
+from pyimcom.coadd import Block, InImage
 from pyimcom.compress.compressutils import CompressedOutput, ReadFile
 from pyimcom.config import Config
 from pyimcom.diagnostics.layer_diagnostics import LayerReport
@@ -789,6 +789,35 @@ def setup(tmp_path_factory):
                 os.remove(fname1)
 
     return tmp_path
+
+
+def test_inimageutils(setup):
+    """Test InImage utilities that didn't get covered in the main tests."""
+
+    tmp_path = setup  # get the test directory
+
+    # now build an InImage
+    cfg = Config(str(tmp_path / "cfg_piff.txt"))
+    blk = Block(cfg=cfg, this_sub=1, run_coadd=False)
+    blk.parse_config()
+    inimg = InImage(blk, (10, 12))
+    testpoint = (60.05, -3.79)
+
+    # and now draw the PSF 4 times, and we'll check that each time it changes
+    psf1 = inimg.get_psf_pos(testpoint)
+    psf2 = inimg.get_psf_pos(testpoint, use_drawpsf=True)
+    psf3 = inimg.get_psf_pos(testpoint)
+    psf4 = inimg.get_psf_pos(testpoint, use_drawpsf=True)
+    assert np.allclose(psf1, psf3)
+    assert np.allclose(psf2, psf4)
+    assert 0.8 < np.sum(psf1) < 1.2
+    assert 0.8 < np.sum(psf2) < 1.2
+    assert np.shape(psf1) != np.shape(psf2)  # should be different
+
+    # now clear
+    inimg.clear()
+    for a in ["inpsf_arr", "inpsf_cube", "inpsf_piff"]:
+        assert not hasattr(inimg, a)
 
 
 def test_drawlayers(setup):

--- a/tests/pyimcom/test_pyimcom.py
+++ b/tests/pyimcom/test_pyimcom.py
@@ -917,7 +917,7 @@ def test_altdrawlayers(tmp_path, setup):
 
     # test Piff drew a correctly normalized star and galaxy
     ys, xs = 3014, 3063
-    with fits.open("") as f:
+    with fits.open(str(tmp_path) + "/cache/in_alt_00000010_12.fits") as f:
         for simlayer in range(1, 4):
             sm = np.sum(f[0].data[simlayer, ys - 16 : ys + 17, xs - 16 : xs + 17])
             assert 1.02 < sm < 1.2

--- a/tests/pyimcom/test_pyimcom.py
+++ b/tests/pyimcom/test_pyimcom.py
@@ -6,9 +6,11 @@ This does 2 blocks.
 
 import copy
 import io
+import json
 import os
 import pathlib
 import re
+import urllib.request
 from contextlib import redirect_stdout
 
 import asdf
@@ -44,6 +46,8 @@ from scipy.signal import convolve
 EXAMPLE_FILE = (
     "https://github.com/Roman-HLIS-Cosmology-PIT/pyimcom/wiki/test-files/compressiontest_F_02_11.fits"
 )
+
+PIFF_FILE = "https://github.com/Roman-HLIS-Cosmology-PIT/pyimcom/wiki/test-files/ffov_13906_17.piff"
 
 # constants
 degree = np.pi / 180.0
@@ -749,16 +753,48 @@ def setup(tmp_path):
     cfg_alt = Config(tmp_path / "cfg_alt.txt")
     Block(cfg=cfg_alt, this_sub=1)
 
+    # build config for Piff run
+    with open(str(tmp_path) + "/cfg_alt.txt") as f:
+        cfgdict = json.loads(f.read())
+    cfgdict["INPSFDRAW"][1] = "Piff:psf_temp"
+    cfgdict["INPSFDRAW"][2] = 4  # 4x4 oversampling
+    cfgdict["OUT"] = str(tmp_path) + "/out/testout_F"
+    cfgdict["EXTRAINPUT"] = ["gsstar12", "gsext12,seed=100,shear=-.5,0", "cstar12"]
+    with open(tmp_path / "cfg_piff.txt", "w") as f:
+        f.write(json.dumps(cfgdict))
+    del cfgdict
+    # get Piff files
+    urllib.request.urlretrieve(PIFF_FILE, str(tmp_path) + "/temp.piff")
+
     # remove stuff we don't need
+    hasntremovedanything = False
+    for iobs in range(len(obs)):
+        delpsf = False
+        for sca in range(1, 19):
+            fname3 = cachedir / rf"in_alt_{iobs:08d}_{sca:02d}.fits"
+            if os.path.exists(fname3):
+                os.remove(fname3)
+                delpsf = True
+        # ... including replacing the PSF files
+        if delpsf:
+            os.symlink(str(tmp_path) + "/temp.piff", str(tmp_path) + f"/psfalt/psf_temp_{iobs:d}.piff")
+            if not hasntremovedanything:
+                os.remove(str(tmp_path) + f"/psfalt/psf_polyfit_{iobs:d}.fits")
+                hasntremovedanything = True
+
+    # run one block of Piff
+    cfg_piff = Config(tmp_path / "cfg_piff.txt")
+    Block(cfg=cfg_piff, this_sub=1)
+    with open("cachedir.txt", "w") as f:
+        f.write(cachedir)
+
+    # now clean up everything, including the input files
     for iobs in range(len(obs)):
         for sca in range(1, 19):
             fname1 = tmp_path / rf"in/sim_L2_F184_{iobs:d}_{sca:d}.asdf"
             fname2 = cachedir / rf"in_{iobs:08d}_{sca:02d}.fits"
             if os.path.exists(fname1) and not os.path.exists(fname2):
                 os.remove(fname1)
-            fname3 = cachedir / rf"in_alt_{iobs:08d}_{sca:02d}.fits"
-            if os.path.exists(fname3):
-                os.remove(fname3)
 
 
 def test_drawlayers(tmp_path, setup):
@@ -854,26 +890,32 @@ def test_altdrawlayers(tmp_path, setup):
     xm = int(np.round(xs))
     ym = int(np.round(ys))
 
-    with fits.open(tmp_path / "out/testout_F_00_01.fits") as fblock:
-        moms = galsim.Image(fblock[0].data[0, 1, ym - 8 : ym + 9, xm - 8 : xm + 9]).FindAdaptiveMom()
-        print(moms)
-    with fits.open(tmp_path / "out/testout_F_alt_00_01.fits") as fblock:
-        momsalt = galsim.Image(fblock[0].data[0, 1, ym - 8 : ym + 9, xm - 8 : xm + 9]).FindAdaptiveMom()
-        print(momsalt)
+    for simlayer in range(1, 5):
+        with fits.open(tmp_path / "out/testout_F_00_01.fits") as fblock:
+            moms = galsim.Image(
+                fblock[0].data[0, simlayer, ym - 8 : ym + 9, xm - 8 : xm + 9]
+            ).FindAdaptiveMom()
+            print(moms)
+        with fits.open(tmp_path / "out/testout_F_alt_00_01.fits") as fblock:
+            momsalt = galsim.Image(
+                fblock[0].data[0, simlayer, ym - 8 : ym + 9, xm - 8 : xm + 9]
+            ).FindAdaptiveMom()
+            print(momsalt)
 
-    # check the object didn't move
-    assert (
-        np.hypot(
-            moms.moments_centroid.x - momsalt.moments_centroid.x,
-            moms.moments_centroid.y - momsalt.moments_centroid.y,
+        # check the object didn't move
+        assert (
+            np.hypot(
+                moms.moments_centroid.x - momsalt.moments_centroid.x,
+                moms.moments_centroid.y - momsalt.moments_centroid.y,
+            )
+            < 0.05
         )
-        < 0.05
-    )
-    # change in amplitude
-    assert 0.99 < moms.moments_amp / momsalt.moments_amp < 1.01
-    # difference in sigma
-    dsig2 = moms.moments_sigma**2 - momsalt.moments_sigma**2
-    assert 0.08 < dsig2 * sc < 0.1
+        # change in amplitude
+        assert 0.99 < moms.moments_amp / momsalt.moments_amp < 1.01
+        # difference in sigma
+        dsig2 = moms.moments_sigma**2 - momsalt.moments_sigma**2
+        q = 0.04 if simlayer == 2 else 0.01
+        assert 0.09 - q < dsig2 * sc < 0.09 + q
 
 
 def test_PyIMCOM_run1(tmp_path, setup):

--- a/tests/pyimcom/test_pyimcom.py
+++ b/tests/pyimcom/test_pyimcom.py
@@ -759,7 +759,7 @@ def setup(tmp_path):
     cfgdict["INPSFDRAW"][1] = "Piff:psf_temp"
     cfgdict["INPSFDRAW"][2] = 4  # 4x4 oversampling
     cfgdict["OUT"] = str(tmp_path) + "/out/testout_F_piff"
-    cfgdict["EXTRAINPUT"] = ["gsstar12", "gsext12,seed=100,shear=-.5,0", "cstar12"]
+    cfgdict["EXTRAINPUT"] = ["gsstar12", "gsext12,seed=100,shear=-.5,0", "cstar12", "whitenoise1"]
     with open(tmp_path / "cfg_piff.txt", "w") as f:
         f.write(json.dumps(cfgdict))
     del cfgdict
@@ -767,20 +767,24 @@ def setup(tmp_path):
     urllib.request.urlretrieve(PIFF_FILE, str(tmp_path) + "/temp.piff")
 
     # remove stuff we don't need
-    hasntremovedanything = False
     for iobs in range(len(obs)):
         delpsf = False
         for sca in range(1, 19):
             fname3 = cachedir / rf"in_alt_{iobs:08d}_{sca:02d}.fits"
             if os.path.exists(fname3):
-                os.remove(fname3)
                 delpsf = True
         # ... including replacing the PSF files
         if delpsf:
             os.symlink(str(tmp_path) + "/temp.piff", str(tmp_path) + f"/psfalt/psf_temp_{iobs:d}.piff")
-            if not hasntremovedanything:
-                os.remove(str(tmp_path) + f"/psfalt/psf_polyfit_{iobs:d}.fits")
-                hasntremovedanything = True
+            os.remove(str(tmp_path) + f"/psfalt/psf_polyfit_{iobs:d}.fits")
+
+    # this is supposed to just remove one file, and the ancillary files
+    iobs, sca = 10, 12
+    os.remove(cachedir / rf"in_alt_{iobs:08d}_{sca:02d}.fits.lock")
+    os.remove(cachedir / rf"in_alt_{iobs:08d}_{sca:02d}.fits")
+    os.remove(cachedir / rf"in_alt_{iobs:08d}_{sca:02d}_mask.fits.lock")
+    os.remove(cachedir / rf"in_alt_{iobs:08d}_{sca:02d}_mask.fits")
+    os.remove(cachedir / rf"in_alt_{iobs:08d}_{sca:02d}_wcs.asdf")
 
     # run one block of Piff
     cfg_piff = Config(tmp_path / "cfg_piff.txt")

--- a/tests/pyimcom/test_pyimcom.py
+++ b/tests/pyimcom/test_pyimcom.py
@@ -814,11 +814,6 @@ def test_inimageutils(setup):
     assert 0.8 < np.sum(psf2) < 1.2
     assert np.shape(psf1) != np.shape(psf2)  # should be different
 
-    # now clear
-    inimg.clear()
-    for a in ["inpsf_arr", "inpsf_cube", "inpsf_piff"]:
-        assert not hasattr(inimg, a)
-
 
 def test_drawlayers(setup):
     """See if we can successfully draw layers with the build_all_layers function."""

--- a/tests/pyimcom/test_pyimcom.py
+++ b/tests/pyimcom/test_pyimcom.py
@@ -409,21 +409,11 @@ def make_simple_wcs(ra, dec, pa, sca):
     return outwcs
 
 
-@pytest.fixture
-def setup(tmp_path):
-    """
-    Generates sample input files for a pyimcom run.
+@pytest.fixture(scope="module")
+def setup(tmp_path_factory):
+    """Generates sample input files for a pyimcom run."""
 
-    Parameters
-    ----------
-    tmp_path : str
-        Directory in which to run the test.
-
-    Returns
-    -------
-    None
-
-    """
+    tmp_path = tmp_path_factory.mktemp("pyimcomtests")  # so we can use function scope
 
     # first, get the configuration file.
     with open(tmp_path / "cfg.txt", "w") as f:
@@ -798,23 +788,13 @@ def setup(tmp_path):
             if os.path.exists(fname1) and not os.path.exists(fname2):
                 os.remove(fname1)
 
+    return tmp_path
 
-def test_drawlayers(tmp_path, setup):
-    """
-    See if we can successfully draw layers with the build_all_layers function.
 
-    Parameters
-    ----------
-    tmp_path : str
-        Directory in which to run the test.
-    setup : function
-        For pytest fixture.
+def test_drawlayers(setup):
+    """See if we can successfully draw layers with the build_all_layers function."""
 
-    Returns
-    -------
-    None
-
-    """
+    tmp_path = setup  # get the test directory
 
     # first, get the configuration file.
     with open(tmp_path / "cfg2.txt", "w") as f:
@@ -862,22 +842,10 @@ def test_drawlayers(tmp_path, setup):
             assert np.allclose(d1[0].data, d2[0].data)
 
 
-def test_altdrawlayers(tmp_path, setup):
-    """
-    Examine drawlayer with alternate PSF.
+def test_altdrawlayers(setup):
+    """Examine drawlayer with alternate PSF."""
 
-    Parameters
-    ----------
-    tmp_path : str
-        Directory in which to run the test.
-    setup : function
-        For pytest fixture.
-
-    Returns
-    -------
-    None
-
-    """
+    tmp_path = setup  # get the test directory
 
     with fits.open(tmp_path / "out/testout_F_TruthCat.fits") as f_inj:
         # get the first star in the table --- in this case, it's the only one
@@ -927,22 +895,10 @@ def test_altdrawlayers(tmp_path, setup):
             assert 1.02 < sm < 1.2
 
 
-def test_PyIMCOM_run1(tmp_path, setup):
-    """
-    Examine PyIMCOM outputs.
+def test_PyIMCOM_run1(setup):
+    """Examine PyIMCOM outputs."""
 
-    Parameters
-    ----------
-    tmp_path : str
-        Directory in which to run the test.
-    setup : function
-        For pytest fixture.
-
-    Returns
-    -------
-    None
-
-    """
+    tmp_path = setup  # get the test directory
 
     ## Science star portion ##
 
@@ -1326,8 +1282,10 @@ def test_compress(tmp_path):
                     )
 
 
-def test_visualize(tmp_path, setup, monkeypatch):
+def test_visualize(setup, monkeypatch):
     """Test function to direct visualizations to files."""
+
+    tmp_path = setup  # get the test directory
 
     # new place to save figures, in sequence
     _counter = [0]
@@ -1385,8 +1343,10 @@ class _DummyImage:
         self.indata = np.zeros((4088, 4088), dtype=np.float32)
 
 
-def test_masks(tmp_path, setup):
+def test_masks(setup):
     """Simple tests for mask functions."""
+
+    tmp_path = setup  # get the test directory
 
     # This one tests masks for old formats (unlikely to use again, but we want to make sure
     # the code still works).

--- a/tests/pyimcom/test_pyimcom.py
+++ b/tests/pyimcom/test_pyimcom.py
@@ -116,6 +116,59 @@ myCfg_format = """
 }
 """
 
+myCfg_alt_format = """
+{
+    "OBSFILE": "$TMPDIR/obs.fits",
+    "INDATA": [
+        "$TMPDIR/in",
+        "L2_2506"
+    ],
+    "CTR": [
+	60.0504,
+	-3.8
+    ],
+    "LONPOLE": 240.0,
+    "OUTSIZE": [
+        4,
+	25,
+	0.04
+    ],
+    "BLOCK": 2,
+    "FILTER": 1,
+    "LAKERNEL": "Cholesky",
+    "KAPPAC": [
+         5e-4
+    ],
+    "INPSF": [
+	"$TMPDIR/psf",
+        "L2_2506",
+        6
+    ],
+    "INPSFDRAW": [
+	"$TMPDIR/psfalt",
+        "L2_2506",
+        6
+    ],
+    "EXTRAINPUT": [
+        "gsstar14",
+        "gsext14,seed=100,shear=-.01:0.017320508075688773",
+        "cstar14",
+        "nstar14,2e5,100,256"
+    ],
+    "PADSIDES": "all",
+    "OUTMAPS": "USTKN",
+    "OUT": "$TMPDIR/out/testout_F_alt",
+    "INPAD": 0.8,
+    "NPIXPSF": 42,
+    "FADE": 1,
+    "PAD": 0,
+    "NOUT": 1,
+    "OUTPSF": "GAUSSIAN",
+    "EXTRASMOOTH": 0.9265328730414752,
+    "INLAYERCACHE": "$TMPDIR/cache/in_alt"
+}
+"""
+
 # CD and CRPIX values for linear approximations to the SCA WCSs.
 wcsdata = np.array(
     [
@@ -371,6 +424,8 @@ def setup(tmp_path):
     # first, get the configuration file.
     with open(tmp_path / "cfg.txt", "w") as f:
         f.write(myCfg_format.replace("$TMPDIR", str(tmp_path)))
+    with open(tmp_path / "cfg_alt.txt", "w") as f:
+        f.write(myCfg_alt_format.replace("$TMPDIR", str(tmp_path)))
 
     # now make the observation file
     obs = []
@@ -406,6 +461,17 @@ def setup(tmp_path):
         fits.HDUList(imfits).writeto(tmp_path / f"psf/psf_polyfit_{i:d}.fits", overwrite=True)
     ns_psf = np.shape(psf[-1])[0]
     ctr_psf = (ns_psf - 1) / 2.0
+
+    # alternate PSFs --- this one is smaller by 0.3 pix rms per axis
+    (tmp_path / "psfalt").mkdir(parents=True, exist_ok=True)
+    for i in range(len(obs)):
+        psfalt = OutPSF.psf_cplx_airy(ov * 20, ov * 1.326, sigma=0.0, features=i % 8)
+        psf_cube = np.zeros((4,) + np.shape(psfalt), dtype=np.float32)
+        psf_cube[0, :, :] = psfalt
+        imfits = [fits.PrimaryHDU()]
+        for _ in range(18):
+            imfits.append(fits.ImageHDU(psf_cube))
+        fits.HDUList(imfits).writeto(tmp_path / f"psfalt/psf_polyfit_{i:d}.fits", overwrite=True)
 
     # tophat kernel
     tk = np.ones(ov + 1)
@@ -679,6 +745,10 @@ def setup(tmp_path):
     assert np.all(np.isnan(t))  # we didn't save these so should get nan
     s.clear()
 
+    # Rnow with alternative PSF for drawing (make smaller objects)
+    cfg_alt = Config(tmp_path / "cfg_alt.txt")
+    Block(cfg=cfg_alt, this_sub=1)
+
     # remove stuff we don't need
     for iobs in range(len(obs)):
         for sca in range(1, 19):
@@ -686,6 +756,9 @@ def setup(tmp_path):
             fname2 = cachedir / rf"in_{iobs:08d}_{sca:02d}.fits"
             if os.path.exists(fname1) and not os.path.exists(fname2):
                 os.remove(fname1)
+            fname3 = cachedir / rf"in_alt_{iobs:08d}_{sca:02d}.fits"
+            if os.path.exists(fname3):
+                os.remove(fname3)
 
 
 def test_drawlayers(tmp_path, setup):
@@ -749,6 +822,58 @@ def test_drawlayers(tmp_path, setup):
         with fits.open(f1) as d1, fits.open(f2) as d2:
             # print(id, sca, d1[0].data, d2[0].data)
             assert np.allclose(d1[0].data, d2[0].data)
+
+
+def test_altdrawlayers(tmp_path, setup):
+    """
+    Examine drawlayer with alternate PSF.
+
+    Parameters
+    ----------
+    tmp_path : str
+        Directory in which to run the test.
+    setup : function
+        For pytest fixture.
+
+    Returns
+    -------
+    None
+
+    """
+
+    with fits.open(tmp_path / "out/testout_F_TruthCat.fits") as f_inj:
+        # get the first star in the table --- in this case, it's the only one
+        ibx = f_inj["TRUTH14"].data["ibx"][0]
+        iby = f_inj["TRUTH14"].data["iby"][0]
+        xs = f_inj["TRUTH14"].data["x"][0]
+        ys = f_inj["TRUTH14"].data["y"][0]
+        assert ibx == 0
+        assert iby == 1
+
+    # which region to take
+    xm = int(np.round(xs))
+    ym = int(np.round(ys))
+
+    with fits.open(tmp_path / "out/testout_F_00_01.fits") as fblock:
+        moms = galsim.Image(fblock[0].data[0, 1, ym - 8 : ym + 9, xm - 8 : xm + 9]).FindAdaptiveMom()
+        print(moms)
+    with fits.open(tmp_path / "out/testout_F_alt_00_01.fits") as fblock:
+        momsalt = galsim.Image(fblock[0].data[0, 1, ym - 8 : ym + 9, xm - 8 : xm + 9]).FindAdaptiveMom()
+        print(momsalt)
+
+    # check the object didn't move
+    assert (
+        np.hypot(
+            moms.moments_centroid.x - momsalt.moments_centroid.x,
+            moms.moments_centroid.y - momsalt.moments_centroid.y,
+        )
+        < 0.05
+    )
+    # change in amplitude
+    assert 0.99 < moms.moments_amp / momsalt.moments_amp < 1.01
+    # difference in sigma
+    dsig2 = moms.moments_sigma**2 - momsalt.moments_sigma**2
+    assert 0.08 < dsig2 * sc < 0.1
 
 
 def test_PyIMCOM_run1(tmp_path, setup):


### PR DESCRIPTION
This PR will enable us to draw object layers with the Piff PSF (directly, without using the Legendre expansion / truncation errors). It also allows these to be drawn with a different model than the IMCOM linear algebra.

We're still working on speeding up the Piff drawing, it is slow right now.